### PR TITLE
Capability to publish to multiple topics

### DIFF
--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -14,6 +14,7 @@ Minimal configuration:
         server_url = mqtt://username:password@localhost:1883/
         topic = weather
         unit_system = METRIC
+        persist_connection = False # persist the connection across publishing data
 
 Other MQTT options can be specified:
 

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -85,6 +85,26 @@ Paho client tls_set method.  Refer to Paho client documentation for details:
             #   To specify multiple cyphers, delimit with commas and enclose
             #   in quotes.
             #ciphers =
+            
+Publish to multiple topics and override options specified above:
+
+[StdRestful]
+    [[MQTT]]
+        [[[topics]]]
+            [[[[topic-1]]]]
+                unit_system = METRIC
+                aggregation = individual, aggregate # individual, aggregate, or both
+                binding = loop # options are loop or archive
+                augment_record = True
+                qos = 1        # options are 0, 1, 2
+                retain = true  # options are true or false
+                [[[[[inputs]]]]]
+                    [[[[[[outTemp]]]]]]
+                        name = inside_temperature  # use a label other than outTemp
+                        format = %.2f              # two decimal places of precision
+                        units = degree_F           # convert outTemp to F, others in C      
+          [[[[topic-2]]]]
+    
 """
 
 try:
@@ -300,7 +320,6 @@ class MQTT(weewx.restx.StdRESTbase):
         self.archive_thread = MQTTThread(self.archive_queue, **mqtt_dict)
         self.archive_thread.start()
 
-        # TODO handle binding at topic level
         if archive_binding:
             self.bind(weewx.NEW_ARCHIVE_RECORD, self.new_archive_record)
         if loop_binding:

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -304,6 +304,8 @@ class MQTT(weewx.restx.StdRESTbase):
         mqtt_dict['server_url'] = site_dict['server_url']
         mqtt_dict['client_id'] = site_dict.get('client_id', '')
         mqtt_dict['persist_connection'] = to_bool(site_dict.get('persist_connection', False))
+        mqtt_dict['log_success'] = to_bool(site_dict.get('log_success', True))
+        mqtt_dict['log_failure'] = to_bool(site_dict.get('log_failure', True))
 
         augment_record = False
         archive_binding = False

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -136,9 +136,9 @@ except (ImportError, AttributeError):
 import weewx
 import weewx.restx
 import weewx.units
-from weeutil.weeutil import to_int, to_bool, accumulateLeaves
+from weeutil.weeutil import to_int, to_bool
 
-VERSION = "0.23-rmb-01"
+VERSION = "0.23"
 
 if weewx.__version__ < "3":
     raise weewx.UnsupportedFeature("weewx 3 is required, found %s" %
@@ -264,7 +264,6 @@ class MQTT(weewx.restx.StdRESTbase):
         loginf("service version is %s" % VERSION)
         try:
             site_dict = config_dict['StdRESTful']['MQTT']
-            #site_dict = accumulateLeaves(site_dict, max_level=1)
             site_dict['server_url']
         except KeyError as e:
             logerr("Data will not be uploaded: Missing option %s" % e)

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -137,6 +137,11 @@ import weewx
 import weewx.restx
 import weewx.units
 from weeutil.weeutil import to_int, to_bool
+try:
+    from weeutil.config import search_up
+except ImportError:
+    # pre 3.9.0
+    from weeutil.weeutil import search_up
 
 VERSION = "0.23"
 
@@ -305,12 +310,12 @@ class MQTT(weewx.restx.StdRESTbase):
         mqtt_dict['client_id'] = site_dict.get('client_id', '')
         mqtt_dict['persist_connection'] = to_bool(site_dict.get('persist_connection', False))
         mqtt_dict['tls'] = site_dict.get('tls', None)
-        mqtt_dict['log_success'] = to_bool(site_dict.get('log_success', True))
-        mqtt_dict['log_failure'] = to_bool(site_dict.get('log_failure', True))
-        mqtt_dict['post_interval'] = to_int(site_dict.get('post_interval', None))
-        mqtt_dict['timeout'] = to_int(site_dict.get('timeout', 60))
-        mqtt_dict['max_tries'] = to_int(site_dict.get('max_tries', 3))
-        mqtt_dict['retry_wait'] = to_int(site_dict.get('retry_wait', 5))
+        mqtt_dict['log_success'] = to_bool(search_up(site_dict, 'log_success', True))
+        mqtt_dict['log_failure'] = to_bool(search_up(site_dict, 'log_failure', True))
+        mqtt_dict['post_interval'] = to_int(search_up(site_dict, 'post_interval', None))
+        mqtt_dict['timeout'] = to_int(search_up(site_dict, 'timeout', 60))
+        mqtt_dict['max_tries'] = to_int(search_up(site_dict, 'max_tries', 3))
+        mqtt_dict['retry_wait'] = to_int(search_up(site_dict, 'retry_wait', 5))
 
         augment_record = False
         archive_binding = False

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -257,7 +257,7 @@ class MQTT(weewx.restx.StdRESTbase):
 
         topic_configs = site_dict.get('topics', {})
         if not topic_configs:
-            topic = site_dict.get('topic', 'weather')
+            topic = site_dict.get('topic', 'weather/loop')
             site_dict['topics'] = {}
             site_dict['topics'][topic] = {}
             topics = {}
@@ -535,8 +535,7 @@ class MQTTThread(weewx.restx.RESTThread):
                 mc.connect(url.hostname, url.port)
                 mc.loop_start()
                 if aggregation.find('aggregate') >= 0:
-                    tpc = topic + '/loop'
-                    (res, mid) = mc.publish(tpc, json.dumps(data),
+                    (res, mid) = mc.publish(topic, json.dumps(data),
                                             retain=retain, qos=qos)
                     if res != mqtt.MQTT_ERR_SUCCESS:
                         logerr("publish failed for %s: %s" % (tpc, res))

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -304,8 +304,13 @@ class MQTT(weewx.restx.StdRESTbase):
         mqtt_dict['server_url'] = site_dict['server_url']
         mqtt_dict['client_id'] = site_dict.get('client_id', '')
         mqtt_dict['persist_connection'] = to_bool(site_dict.get('persist_connection', False))
+        mqtt_dict['tls'] = site_dict.get('tls', None)
         mqtt_dict['log_success'] = to_bool(site_dict.get('log_success', True))
         mqtt_dict['log_failure'] = to_bool(site_dict.get('log_failure', True))
+        mqtt_dict['post_interval'] = to_int(site_dict.get('post_interval', None))
+        mqtt_dict['timeout'] = to_int(site_dict.get('timeout', 60))
+        mqtt_dict['max_tries'] = to_int(site_dict.get('max_tries', 3))
+        mqtt_dict['retry_wait'] = to_int(site_dict.get('retry_wait', 5))
 
         augment_record = False
         archive_binding = False


### PR DESCRIPTION
Provide the ability to publish to multiple topics. The content and format of the MQTT payload is configurable by topic. For example, one topic might bind to WeeWX loop data and a second topic might bind to archive data. Configuring the topics uses the same options currently used (binding, aggregation, unit_system, inputs, etc.). If no topic is configured, the current behavior is the default.

The ability to persist the connection across publishing is also in this pull request. When the ```persist_connection``` option is ```True```, a single connection is created and used to publish. When set to ```False```, the current behavior of creating a connection, publishing, disconnecting is performed. For backwards compatibility, the default is ```False```.

Example ```topics``` configuration:
```
[StdRestful]
    [[MQTT]]
        [[[topics]]]
            [[[[topic-1]]]]
                unit_system = METRIC
                aggregation = individual, aggregate # individual, aggregate, or both
                binding = loop # options are loop or archive
                augment_record = True
                qos = 1        # options are 0, 1, 2
                retain = true  # options are true or false
                [[[[[inputs]]]]]
                    [[[[[[outTemp]]]]]]
                        name = inside_temperature  # use a label other than outTemp
                        format = %.2f              # two decimal places of precision
                        units = degree_F           # convert outTemp to F, others in C
          [[[[topic-2]]]]
```