### PR TITLE
Reusable MQTT client

### DIFF
--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -99,6 +99,7 @@ except ImportError:
 
 import paho.mqtt.client as mqtt
 import random
+import socket
 import sys
 import time
 
@@ -418,6 +419,37 @@ class MQTTThread(weewx.restx.RESTThread):
         self.aggregation = aggregation
         self.templates = dict()
         self.skip_upload = skip_upload
+        self.mc = None
+        self.mc_try_time = 0
+
+    def get_mqtt_client(self):
+        if self.mc:
+            return
+        if time.time() - self.mc_try_time < self.retry_wait:
+            return
+        client_id = self.client_id
+        if not client_id:
+            pad = "%032x" % random.getrandbits(128)
+            client_id = 'weewx_%s' % pad[:8]
+        mc = mqtt.Client(client_id=client_id)
+        url = urlparse(self.server_url)
+        if url.username is not None and url.password is not None:
+            mc.username_pw_set(url.username, url.password)
+        # if we have TLS opts configure TLS on our broker connection
+        if len(self.tls_dict) > 0:
+            mc.tls_set(**self.tls_dict)
+        try:
+            self.mc_try_time = time.time()
+            mc.connect(url.hostname, url.port)
+        except (socket.error, socket.timeout, socket.herror) as e:
+            logerr('Failed to connect to MQTT server (%s): %s' %
+                    (_obfuscate_password(self.server_url), str(e)))
+            self.mc = None
+            return
+        mc.loop_start()
+        loginf('client established for %s' %
+               _obfuscate_password(self.server_url))
+        self.mc = mc
 
     def filter_data(self, record):
         # if uploading everything, we must check the upload variables list
@@ -467,7 +499,6 @@ class MQTTThread(weewx.restx.RESTThread):
         return data
 
     def process_record(self, record, dbm):
-        import socket
         if self.augment_record and dbm is not None:
             record = self.get_record(record, dbm)
         if self.unit_system is not None:
@@ -478,40 +509,21 @@ class MQTTThread(weewx.restx.RESTThread):
         if self.skip_upload:
             loginf("skipping upload")
             return
-        url = urlparse(self.server_url)
-        for _count in range(self.max_tries):
-            try:
-                client_id = self.client_id
-                if not client_id:
-                    pad = "%032x" % random.getrandbits(128)
-                    client_id = 'weewx_%s' % pad[:8]
-                mc = mqtt.Client(client_id=client_id)
-                if url.username is not None and url.password is not None:
-                    mc.username_pw_set(url.username, url.password)
-                # if we have TLS opts configure TLS on our broker connection
-                if len(self.tls_dict) > 0:
-                    mc.tls_set(**self.tls_dict)
-                mc.connect(url.hostname, url.port)
-                mc.loop_start()
-                if self.aggregation.find('aggregate') >= 0:
-                    tpc = self.topic + '/loop'
-                    (res, mid) = mc.publish(tpc, json.dumps(data),
-                                            retain=self.retain, qos=self.qos)
-                    if res != mqtt.MQTT_ERR_SUCCESS:
-                        logerr("publish failed for %s: %s" % (tpc, res))
-                if self.aggregation.find('individual') >= 0:
-                    for key in data:
-                        tpc = self.topic + '/' + key
-                        (res, mid) = mc.publish(tpc, data[key],
-                                                retain=self.retain)
-                        if res != mqtt.MQTT_ERR_SUCCESS:
-                            logerr("publish failed for %s: %s" % (tpc, res))
-                mc.loop_stop()
-                mc.disconnect()
-                return
-            except (socket.error, socket.timeout, socket.herror) as e:
-                logdbg("Failed upload attempt %d: %s" % (_count+1, e))
-            time.sleep(self.retry_wait)
-        else:
-            raise weewx.restx.FailedPost("Failed upload after %d tries" %
-                                         (self.max_tries,))
+        self.get_mqtt_client()
+        if not self.mc:
+            raise weewx.restx.FailedPost('MQTT client not available')
+        if self.aggregation.find('aggregate') >= 0:
+            tpc = self.topic + '/loop'
+            (res, mid) = self.mc.publish(tpc, json.dumps(data),
+                                         retain=self.retain, qos=self.qos)
+            if res != mqtt.MQTT_ERR_SUCCESS:
+                logerr("publish failed for %s: %s" %
+                       (tpc, mqtt.error_string(res)))
+        if self.aggregation.find('individual') >= 0:
+            for key in data:
+                tpc = self.topic + '/' + key
+                (res, mid) = self.mc.publish(tpc, data[key],
+                                             retain=self.retain)
+                if res != mqtt.MQTT_ERR_SUCCESS:
+                    logerr("publish failed for %s: %s" %
+                           (tpc, mqtt.error_string(res)))


### PR DESCRIPTION
Establishing a new MQTT client for each loop iteration is quite wasteful,
especially when TLS is in use. This change establishes and uses a single
client. Automatic reconnection is handled by Paho-MQTT.

For each call to process_record(), we'll check to see if an MQTT client
has already been established. If so, we'll use it. If not, and it's been
at least retry_wait seconds since we last tried, we'll try to establish
one. socket exceptions (expected causes of failure) are caught and logged.
Other exceptions are raised up. If a client is not available to do the
requested publish, a weewx.restx.FailedPost exception is raised.

resolves #9