### PR TITLE
Changes option 'units' to 'unit', but accept old option as well.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+0.24 16apr2022
+* renamed option 'units' to 'unit', although either will be accepted.
+
 0.23 10may2020
 * fixed unit label for specialized observations (thanks to mbradley)
 

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class MQTTInstaller(ExtensionInstaller):
     def __init__(self):
         super(MQTTInstaller, self).__init__(
-            version="0.23",
+            version="0.24",
             name='mqtt',
             description='Upload weather data to MQTT server.',
             author="Matthew Wall",


### PR DESCRIPTION
The option affects only one observation type, so the singular makes more sense.
It also matches the option of the same name in the main WeeWX code base.
See the comments in commit https://github.com/weewx/weewx/commit/77b00e5475034c00a91671967ee68f78e519a2d9