### PR TITLE
Disable the extension by default

### DIFF
--- a/install.py
+++ b/install.py
@@ -19,6 +19,7 @@ class MQTTInstaller(ExtensionInstaller):
             config={
                 'StdRESTful': {
                     'MQTT': {
+                        'enable': 'false',
                         'server_url': 'INSERT_SERVER_URL_HERE'}}},
             files=[('bin/user', ['bin/user/mqtt.py'])]
             )


### PR DESCRIPTION
Please set this extension to disable=false because the default installation puts an invalid placeholder target broker hostname into weewx.conf, resulting in runtime errors if the user hasn't (yet) done their hand edits.

This is a one-liner change.