### PR TITLE
feat: Added Home Assistant discovery into MQTT. This helps HA admins to start ingesting Weewx data with ease.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 .DS_Store
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,35 @@ _aggregation_ - How the observations should be grouped.  Options are `individual
 
 _retain_ - When set to `True`, the MQTT `retain` property is set for each message.  Default is `False`.
 
-_client_id_ - Use this mqtt client ID (optional)
+_qos_ - The MQTT quality of service for each message: `0` (at most once), `1` (at least once), or `2` (exactly once).  Default is `1`.  At qos `0` the client silently discards anything published while the connection to the broker is down, so a momentary outage loses the record; at qos `1` or above the message is queued and delivered once the connection is back, and the broker acknowledges it.
+
+_client_id_ - Use this mqtt client ID (optional).  An MQTT broker permits only one connection per client identifier and disconnects the older connection when a second one presents the same id.  If you set this, running `weectl rest run MQTT` by hand will therefore kick the running weewx daemon off the broker.  Leaving it unset (the default) gives each connection a random id and avoids this.
+
+### Connection robustness
+
+The connection to the broker is verified before every post and rebuilt if it has been lost, and a post that fails is retried on a fresh connection.  A record that still cannot be delivered is reported to weewx as a failed post rather than silently dropped.
+
+The defaults suit an archive binding.  If you use `binding = loop`, lower the timeouts so that a broker outage cannot stall the posting thread between packets, and set `max_backlog` to bound the queue of pending packets.
+
+_keepalive_ - The MQTT keepalive interval, in seconds.  The broker declares the client dead if it hears nothing for 1.5x this.  Default is `60`.
+
+_connect_timeout_ - How long to wait for the broker to acknowledge a connection, in seconds.  Default is `10`.
+
+_publish_timeout_ - How long to wait for the broker to confirm delivery of a message, in seconds.  Only meaningful when `qos` is `1` or `2`; set to `0` to publish without waiting for confirmation.  Default is `10`.
+
+_reconnect_min_delay_, _reconnect_max_delay_ - Bounds on the delay between the client's own reconnection attempts, in seconds.  The delay doubles from min to max.  Defaults are `1` and `120`.
+
+_max_tries_ - How many times to try posting a record before giving up.  Default is `3`.
+
+_retry_wait_ - How long to wait between attempts, in seconds.  Default is `5`.
+
+Worst case, a record occupies the posting thread for `max_tries x (connect_timeout + publish_timeout + retry_wait)` seconds before it is abandoned.
+
+With verification, data sending errors, such as:
+```text
+ERROR user.mqtt: publish failed for weather/weewx/loop: The client is not currently connected.
+```
+Should be absent.
 
 ### Topic names
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,75 @@ For publishing aggregate data, the topic is TOPIC/loop, and the content is a jso
 Note that the choice of topic names (including unit suffixes) and units used in the contents forms a protocol and the configuration of this extension and of other programs that consume this data must match.
 
 
+### Home Assistant discovery
+
+This extension can announce its observations to [Home Assistant](https://www.home-assistant.io/)
+using [MQTT discovery](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery),
+so the sensors appear automatically without any manual entity configuration.
+
+```
+[StdRESTful]
+    [[MQTT]]
+        ...
+        # To send metric/SI units to Home Assistant, convert the published data
+        # with the standard unit_system option (US, METRIC, or METRICWX). If this
+        # is not set, the station's native units are published and announced.
+        unit_system = METRICWX
+        [[[ha_discovery]]]
+            # Turn on Home Assistant discovery
+            enable = true
+            # Topic prefix Home Assistant listens on (default: homeassistant)
+            discovery_prefix = homeassistant
+            # Identifier for this station's node/device (default: weewx)
+            node_id = weewx
+            # Prefix for the entities' unique ids (default: weewx)
+            unique_id_prefix = weewx
+            # Observations to leave OUT of Home Assistant discovery, comma-
+            # separated. NOTE: this only suppresses the discovery message for
+            # these fields -- they are STILL published as normal MQTT data. It
+            # does not stop them from being sent. (usUnits and interval never get
+            # a discovery message.)
+            skip_fields = inTemp, inHumidity
+            [[[[device]]]]
+                # All values optional; sensible defaults are taken from [Station].
+                name = My Weather Station
+                manufacturer = WeeWX
+                model = Vantage Pro2
+                identifiers = weewx
+```
+
+Notes:
+
+* Discovery describes the data **exactly as it is published**, including its
+  units. Whether values are converted is entirely up to you, via the existing
+  `unit_system` option: leave it unset to publish (and announce) the station's
+  native units (e.g. `°F`, `inHg`), or set `unit_system = METRICWX` to publish
+  and announce metric/SI units (`°C`, `hPa`, `mm`, `m/s`). This works for any
+  station regardless of the units it natively reports.
+* **`skip_fields` does not stop a field from being published over MQTT.** It only
+  suppresses the Home Assistant *discovery* message for that field, so no HA
+  entity is auto-created for it. The field's data is still sent on its normal
+  topic / in the aggregate packet exactly as before; you can still subscribe to
+  it or add it to Home Assistant manually. `usUnits` and `interval` never get a
+  discovery message.
+* `dateTime` (the time of the observation) is published as a Home Assistant
+  `timestamp` entity named **Observation Time** (`weewx_observation_time`). Its
+  Unix-epoch value is converted to a datetime in the discovery `value_template`.
+* Discovery messages are published **once**, **retained**, just before the first
+  data packet is sent. Because they are retained, Home Assistant will pick them
+  up even if it (re)starts later, and re-sending them on each weewx restart is
+  harmless.
+* You can also (re)publish discovery on demand, without waiting for weewx to send
+  a packet, using the `weectl rest` command:
+
+  ```
+  weectl rest run MQTT --discovery
+  ```
+
+  This publishes the discovery messages (using the most recent archive record to
+  determine the available observations) and then exits.
+
+
 ### TLS Options
 
 This extension supports the use of encrypted connections to the broker using TLS.  The TLS options will be passed to Paho client tls_set method.  Refer to Paho client documentation for details:

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -23,6 +23,41 @@ Other MQTT options can be specified:
         qos = 1        # options are 0, 1, 2
         retain = true  # options are true or false
 
+Connection robustness.  The connection to the broker is verified before every
+post and rebuilt if it has been lost, and a failed post is retried.  The
+defaults suit an archive binding; if you bind to loop packets, lower the
+timeouts so a broker outage cannot stall the posting thread between packets,
+and set 'max_backlog' to bound the queue.
+
+[StdRestful]
+    [[MQTT]]
+        ...
+        # MQTT keepalive interval, in seconds.  The broker declares the client
+        # dead if it hears nothing for 1.5x this.  Default is 60.
+        keepalive = 60
+        # How long to wait for the broker to acknowledge a connection
+        # (CONNACK), in seconds.  Default is 10.
+        connect_timeout = 10
+        # How long to wait for the broker to confirm delivery of a message, in
+        # seconds.  Only meaningful when qos is 1 or 2; set to 0 to publish
+        # without waiting for confirmation.  Default is 10.
+        publish_timeout = 10
+        # Bounds on the delay between the client's own reconnect attempts, in
+        # seconds.  The delay doubles from min to max.  Defaults are 1 and 120.
+        reconnect_min_delay = 1
+        reconnect_max_delay = 120
+        # How many times to try posting a record, and how long to wait between
+        # attempts, in seconds.  Defaults are 3 and 5.
+        max_tries = 3
+        retry_wait = 5
+
+Note on 'client_id': an MQTT broker permits only one connection per client
+identifier, and disconnects the older connection when a second one presents the
+same id.  If you set 'client_id' explicitly, running 'weectl rest run MQTT' by
+hand will therefore kick the running weewx daemon off the broker.  Leaving
+'client_id' unset (the default) gives each connection a random id and avoids
+this entirely.
+
 The observations can be sent individually, or in an aggregated packet:
 
 [StdRestful]
@@ -111,7 +146,17 @@ import random
 import re
 import socket
 import sys
+import threading
 import time
+
+try:
+    # paho-mqtt 2.0 introduced a callback API version, and the callback
+    # signatures differ between the two versions.  Probe once here so the rest
+    # of the module can work with either.
+    from paho.mqtt.enums import CallbackAPIVersion
+    PAHO2 = True
+except ImportError:
+    PAHO2 = False
 
 try:
     import cjson as json
@@ -126,9 +171,15 @@ except (ImportError, AttributeError):
 import weewx
 import weewx.restx
 import weewx.units
-from weeutil.weeutil import to_int, to_bool, accumulateLeaves
+from weeutil.weeutil import to_int, to_float, to_bool, accumulateLeaves
 
-VERSION = "0.25"
+VERSION = "0.26"
+
+# How long to let the client finish a reconnect of its own before giving up on
+# it and building a new one.  Short on purpose: a client that is genuinely
+# reconnecting recovers well within this, and one that is not is dead and can
+# never publish again, so there is nothing to gain by waiting longer.
+RECONNECT_GRACE = 2.0
 
 if weewx.__version__ < "3":
     raise weewx.UnsupportedFeature("weewx 3 is required, found %s" %
@@ -162,6 +213,19 @@ def _compat(d, old_label, new_label):
     if old_label in d and new_label not in d:
         d.setdefault(new_label, d[old_label])
         d.pop(old_label)
+
+def _rc_string(rc):
+    """Render a paho result code.
+
+    paho 1.x reports plain ints, paho 2.x a ReasonCode object which is not an
+    int and which error_string() renders as "Unknown error." -- unhelpfully
+    hiding, for example, "Session taken over", the broker's way of saying
+    another client connected with the same client_id.
+    """
+    if isinstance(rc, int):
+        return mqtt.error_string(rc)
+    return str(rc)
+
 
 def _obfuscate_password(url):
     parts = urlparse(url)
@@ -388,8 +452,16 @@ class MQTT(weewx.restx.StdRESTbase):
         site_dict.setdefault('augment_record', True)
         site_dict.setdefault('obs_to_upload', 'all')
         site_dict.setdefault('retain', False)
-        site_dict.setdefault('qos', 0)
+        # qos 1 (at least once) is the default: at qos 0 the client silently
+        # drops anything published while the connection is down, so a momentary
+        # outage loses the record outright.
+        site_dict.setdefault('qos', 1)
         site_dict.setdefault('aggregation', 'individual,aggregate')
+        site_dict.setdefault('keepalive', 60)
+        site_dict.setdefault('connect_timeout', 10)
+        site_dict.setdefault('publish_timeout', 10)
+        site_dict.setdefault('reconnect_min_delay', 1)
+        site_dict.setdefault('reconnect_max_delay', 120)
 
         usn = site_dict.get('unit_system', None)
         if usn is not None:
@@ -408,6 +480,10 @@ class MQTT(weewx.restx.StdRESTbase):
         site_dict['augment_record'] = to_bool(site_dict.get('augment_record'))
         site_dict['retain'] = to_bool(site_dict.get('retain'))
         site_dict['qos'] = to_int(site_dict.get('qos'))
+        site_dict['keepalive'] = to_int(site_dict.get('keepalive'))
+        for opt in ('connect_timeout', 'publish_timeout',
+                    'reconnect_min_delay', 'reconnect_max_delay'):
+            site_dict[opt] = to_float(site_dict.get(opt))
         binding = site_dict.pop('binding', 'archive')
         loginf("binding to %s" % binding)
         data_binding = site_dict.pop('data_binding', 'wx_binding')
@@ -543,8 +619,10 @@ class MQTTThread(weewx.restx.RESTThread):
                  client_id='', topic='', unit_system=None, skip_upload=False,
                  augment_record=True, retain=False, aggregation='individual',
                  inputs={}, obs_to_upload='all', append_units_label=True,
-                 manager_dict=None, tls=None, qos=0,
+                 manager_dict=None, tls=None, qos=1,
                  ha_discovery=None,
+                 keepalive=60, connect_timeout=10, publish_timeout=10,
+                 reconnect_min_delay=1, reconnect_max_delay=120,
                  post_interval=None, stale=None,
                  log_success=True, log_failure=True,
                  timeout=60, max_tries=3, retry_wait=5,
@@ -591,8 +669,25 @@ class MQTTThread(weewx.restx.RESTThread):
         self.aggregation = aggregation
         self.templates = dict()
         self.skip_upload = skip_upload
+        self.keepalive = to_int(keepalive)
+        self.connect_timeout = to_float(connect_timeout)
+        self.publish_timeout = to_float(publish_timeout)
+        self.reconnect_min_delay = to_float(reconnect_min_delay)
+        self.reconnect_max_delay = to_float(reconnect_max_delay)
         self.mc = None
-        self.mc_try_time = 0
+        # Set by on_connect once the broker has acknowledged the connection,
+        # cleared by on_disconnect.  This is what lets us wait for a CONNACK
+        # instead of assuming a socket that has been opened is usable.
+        self._connected = threading.Event()
+        # Set when the broker answers at all, accepting or refusing.  A refusal
+        # is final, so waiting on this rather than on _connected lets a bad
+        # password fail immediately instead of sitting out connect_timeout while
+        # the client retries in the background.
+        self._connack = threading.Event()
+        # The reason code from the most recent CONNACK, so a refused connection
+        # can be reported as itself (e.g. "not authorised") rather than as a
+        # mystery publish failure later on.
+        self._connect_rc = None
         # Home Assistant discovery: config dict (or empty) and a one-time guard.
         self.ha = ha_discovery or {}
         device = self.ha.get('device')
@@ -618,34 +713,194 @@ class MQTTThread(weewx.restx.RESTThread):
         # once, not on every record.
         self._warned_no_usunits = False
 
-    def get_mqtt_client(self):
-        if self.mc:
+    def _on_connect(self, rc):
+        """Called from the client's network thread when a CONNACK arrives."""
+        self._connect_rc = rc
+        self._connack.set()
+        # rc is 0 / Success on acceptance.  Anything else is a refusal (bad
+        # credentials, not authorised, server unavailable, ...) and the client
+        # is not usable.
+        if rc == 0:
+            self._connected.set()
+            loginf('connected to %s' %
+                   _obfuscate_password(self.server_url))
+            # The broker may have been restarted without its retained message
+            # store, which would leave Home Assistant with no discovery
+            # configs.  Re-announcing on every connect is cheap and idempotent
+            # (the messages are retained), so let the next record redo it.
+            self._discovery_sent = False
+        else:
+            self._connected.clear()
+            logerr('connection to %s refused: %s' %
+                   (_obfuscate_password(self.server_url),
+                    mqtt.connack_string(rc)))
+
+    def _on_disconnect(self, rc):
+        """Called from the client's network thread when the connection drops."""
+        self._connected.clear()
+        # Log an unexpected disconnect loudly.  Without this the first sign of
+        # trouble is a failed publish, which for an archive binding may not
+        # happen until the next archive interval.
+        if rc == 0:
+            loginf('disconnected from %s' %
+                   _obfuscate_password(self.server_url))
+        else:
+            logerr('unexpectedly disconnected from %s: %s' %
+                   (_obfuscate_password(self.server_url), _rc_string(rc)))
+
+    def _new_paho_client(self, client_id):
+        """Create a paho client, using whichever callback API is available."""
+        if PAHO2:
+            mc = mqtt.Client(CallbackAPIVersion.VERSION2, client_id=client_id)
+            # paho 2.x: on_connect(client, userdata, flags, reason_code,
+            # properties), on_disconnect(client, userdata, flags, reason_code,
+            # properties).
+            mc.on_connect = \
+                lambda c, u, flags, rc, props=None: self._on_connect(rc)
+            mc.on_disconnect = \
+                lambda c, u, flags, rc, props=None: self._on_disconnect(rc)
+        else:
+            mc = mqtt.Client(client_id=client_id)
+            # paho 1.x: on_connect(client, userdata, flags, rc),
+            # on_disconnect(client, userdata, rc).
+            mc.on_connect = lambda c, u, flags, rc: self._on_connect(rc)
+            mc.on_disconnect = lambda c, u, rc: self._on_disconnect(rc)
+        return mc
+
+    def _teardown_client(self):
+        """Discard the current client.  Safe to call in any state."""
+        mc, self.mc = self.mc, None
+        self._connected.clear()
+        if mc is None:
             return
-        if time.time() - self.mc_try_time < self.retry_wait:
-            return
+        # Both calls can raise if the socket is already gone; that is exactly
+        # the situation we are cleaning up after, so it is not worth reporting.
+        try:
+            mc.disconnect()
+        except Exception as e:
+            logdbg('error while disconnecting client: %s' % e)
+        try:
+            mc.loop_stop()
+        except Exception as e:
+            logdbg('error while stopping client loop: %s' % e)
+
+    def _new_client(self):
+        """Connect a new client and wait for the broker to accept it.
+
+        Raises FailedPost if a usable connection cannot be established.
+        """
         client_id = self.client_id
         if not client_id:
             pad = "%032x" % random.getrandbits(128)
             client_id = 'weewx_%s' % pad[:8]
-        mc = mqtt.Client(client_id=client_id)
+        mc = self._new_paho_client(client_id)
+        mc.reconnect_delay_set(min_delay=self.reconnect_min_delay,
+                               max_delay=self.reconnect_max_delay)
         url = urlparse(self.server_url)
         if url.username is not None and url.password is not None:
             mc.username_pw_set(url.username, url.password)
         # if we have TLS opts configure TLS on our broker connection
         if len(self.tls_dict) > 0:
             mc.tls_set(**self.tls_dict)
+        port = url.port or (8883 if self.tls_dict else 1883)
+        self._connected.clear()
+        self._connack.clear()
+        self._connect_rc = None
         try:
-            self.mc_try_time = time.time()
-            mc.connect(url.hostname, url.port)
-        except (socket.error, socket.timeout, socket.herror) as e:
-            logerr('Failed to connect to MQTT server (%s): %s' %
-                    (_obfuscate_password(self.server_url), str(e)))
-            self.mc = None
-            return
+            mc.connect(url.hostname, port, keepalive=self.keepalive)
+        except (socket.error, socket.timeout, socket.herror, OSError,
+                ValueError) as e:
+            # ValueError covers a malformed server_url (no host, bad port).
+            # Reporting it per record is better than letting it propagate and
+            # terminate the posting thread.
+            raise weewx.restx.FailedPost(
+                'cannot connect to MQTT server (%s): %s' %
+                (_obfuscate_password(self.server_url), e))
         mc.loop_start()
-        loginf('client established for %s' %
-               _obfuscate_password(self.server_url))
         self.mc = mc
+        # connect() only opens the socket and sends the CONNECT packet; the
+        # broker's CONNACK is handled by the network thread started above.
+        # Wait for it, so we never hand back a client that the broker has not
+        # accepted -- otherwise a refused connection only shows up as a failed
+        # publish much later.
+        self._connack.wait(self.connect_timeout)
+        if not self._connected.is_set():
+            rc = self._connect_rc
+            self._teardown_client()
+            if rc is None:
+                raise weewx.restx.FailedPost(
+                    'timed out after %s seconds waiting for MQTT server (%s) '
+                    'to acknowledge the connection' %
+                    (self.connect_timeout,
+                     _obfuscate_password(self.server_url)))
+            raise weewx.restx.FailedPost(
+                'MQTT server (%s) refused the connection: %s' %
+                (_obfuscate_password(self.server_url),
+                 mqtt.connack_string(rc)))
+        logdbg('client established for %s' %
+               _obfuscate_password(self.server_url))
+        return mc
+
+    def _ensure_client(self):
+        """Return a connected client, rebuilding it if the connection is gone.
+
+        Raises FailedPost if no connection can be established.
+        """
+        if self.mc is not None and self.mc.is_connected():
+            return self.mc
+        if self.mc is not None:
+            # The client exists but is not connected.  It may be part way
+            # through its own reconnect, so give that a moment to land before
+            # throwing the client away -- but only a moment, because the client
+            # may equally be permanently dead (paho stops its network thread
+            # for good on some disconnect paths), and a dead client can never
+            # publish again.
+            if self._connected.wait(RECONNECT_GRACE) and self.mc.is_connected():
+                return self.mc
+            loginf('MQTT client is not connected; rebuilding it')
+            self._teardown_client()
+        return self._new_client()
+
+    def _publish(self, messages, retain=None):
+        """Publish a list of (topic, payload) and confirm delivery.
+
+        Raises FailedPost if any message could not be handed to the broker.
+        """
+        if retain is None:
+            retain = self.retain
+        # Publish everything first and collect the message handles, then wait.
+        # Waiting on each message before publishing the next would serialize a
+        # broker round trip per observation; this way the acknowledgements come
+        # back in parallel.
+        pending = []
+        for topic, payload in messages:
+            info = self.mc.publish(topic, payload,
+                                   retain=retain, qos=self.qos)
+            if info.rc != mqtt.MQTT_ERR_SUCCESS:
+                raise weewx.restx.FailedPost(
+                    'publish failed for %s: %s' %
+                    (topic, _rc_string(info.rc)))
+            pending.append((topic, info))
+
+        if not self.qos or not self.publish_timeout:
+            return
+        # At qos 0 publish() is fire and forget, so there is nothing to confirm.
+        # At qos 1 or 2 the broker acknowledges each message, which is the only
+        # real evidence the data arrived.
+        deadline = time.time() + self.publish_timeout
+        for topic, info in pending:
+            try:
+                info.wait_for_publish(max(0.0, deadline - time.time()))
+                published = info.is_published()
+            except (RuntimeError, ValueError) as e:
+                # Raised when the message can no longer be delivered, e.g. the
+                # connection dropped between publishing and waiting.
+                raise weewx.restx.FailedPost(
+                    'publish failed for %s: %s' % (topic, e))
+            if not published:
+                raise weewx.restx.FailedPost(
+                    'timed out after %s seconds waiting for the MQTT server to '
+                    'confirm %s' % (self.publish_timeout, topic))
 
     def filter_data(self, record):
         # if uploading everything, we must check the upload variables list
@@ -821,15 +1076,12 @@ class MQTTThread(weewx.restx.RESTThread):
             logdbg("Home Assistant discovery: record has no describable "
                    "observations; will retry on a later record.")
             return
-        self.get_mqtt_client()
-        if not self.mc:
-            raise weewx.restx.FailedPost('MQTT client not available')
-        for topic, payload in configs:
-            (res, mid) = self.mc.publish(topic, json.dumps(payload),
-                                         retain=True, qos=self.qos)
-            if res != mqtt.MQTT_ERR_SUCCESS:
-                logerr("HA discovery publish failed for %s: %s" %
-                       (topic, mqtt.error_string(res)))
+        self._ensure_client()
+        # Discovery messages are retained so Home Assistant sees them whenever it
+        # (re)starts. A failure here propagates so the caller can retry, rather
+        # than leaving HA with a half-announced device.
+        self._publish([(topic, json.dumps(payload))
+                       for topic, payload in configs], retain=True)
         loginf("published Home Assistant discovery for %d sensors" % len(configs))
         # Only now do we consider discovery done, so a first record that could not
         # be described does not permanently suppress it.
@@ -859,24 +1111,37 @@ class MQTTThread(weewx.restx.RESTThread):
         if self.skip_upload:
             loginf("skipping upload")
             return
-        self.get_mqtt_client()
-        if not self.mc:
-            raise weewx.restx.FailedPost('MQTT client not available')
-        # Publish Home Assistant discovery once, before the first data packet.
-        if self.ha.get('enable') and not self._discovery_sent:
-            self.publish_ha_discovery(record)
+        messages = []
         if self.aggregation.find('aggregate') >= 0:
-            tpc = self.topic + '/loop'
-            (res, mid) = self.mc.publish(tpc, json.dumps(data),
-                                         retain=self.retain, qos=self.qos)
-            if res != mqtt.MQTT_ERR_SUCCESS:
-                logerr("publish failed for %s: %s" %
-                       (tpc, mqtt.error_string(res)))
+            messages.append((self.topic + '/loop', json.dumps(data)))
         if self.aggregation.find('individual') >= 0:
             for key in data:
-                tpc = self.topic + '/' + key
-                (res, mid) = self.mc.publish(tpc, data[key],
-                                             retain=self.retain)
-                if res != mqtt.MQTT_ERR_SUCCESS:
-                    logerr("publish failed for %s: %s" %
-                           (tpc, mqtt.error_string(res)))
+                messages.append((self.topic + '/' + key, data[key]))
+
+        # Try the whole record, connection included, up to max_tries times.
+        # weewx does not retry for us: RESTThread.run_loop only retries posts
+        # made through post_with_retries(), which this thread does not use, so
+        # a FailedPost that escapes here is the end of the road for the record.
+        for attempt in range(self.max_tries):
+            try:
+                self._ensure_client()
+                # Publish Home Assistant discovery before the first data packet,
+                # and again after a reconnect (see _on_connect).
+                if self.ha.get('enable') and not self._discovery_sent:
+                    self.publish_ha_discovery(record)
+                self._publish(messages)
+                return
+            except weewx.restx.FailedPost as e:
+                # A failed publish almost always means the connection has gone,
+                # so discard the client and let the next attempt build a fresh
+                # one.  This is also what keeps the retry exactly-once: at qos 1
+                # or 2 the client holds a message published while disconnected
+                # and would redeliver it on reconnect, so republishing on a
+                # reused client would send every observation twice.
+                self._teardown_client()
+                if attempt + 1 >= self.max_tries:
+                    raise weewx.restx.FailedPost(
+                        'failed after %d attempts: %s' % (self.max_tries, e))
+                loginf('attempt %d of %d failed (%s); retrying in %s seconds' %
+                       (attempt + 1, self.max_tries, e, self.retry_wait))
+                time.sleep(self.retry_wait)

--- a/bin/user/mqtt.py
+++ b/bin/user/mqtt.py
@@ -108,6 +108,7 @@ except ImportError:
 
 import paho.mqtt.client as mqtt
 import random
+import re
 import socket
 import sys
 import time
@@ -127,7 +128,7 @@ import weewx.restx
 import weewx.units
 from weeutil.weeutil import to_int, to_bool, accumulateLeaves
 
-VERSION = "0.24"
+VERSION = "0.25"
 
 if weewx.__version__ < "3":
     raise weewx.UnsupportedFeature("weewx 3 is required, found %s" %
@@ -212,6 +213,129 @@ def _get_template(obs_key, overrides, append_units_label, unit_system):
         if x in overrides:
             tmpl_dict[x] = overrides[x]
     return tmpl_dict
+
+
+# ----------------------------------------------------------------------------
+# Home Assistant MQTT discovery support
+# ----------------------------------------------------------------------------
+#
+# Discovery describes the data *exactly as it is published*. Whether values are
+# converted to metric/SI is left to the admin via the existing 'unit_system'
+# option (US, METRIC, or METRICWX), which converts the whole record before it is
+# published; discovery then reports whatever units that produced. So:
+#   - leave unit_system unset  -> native units published, HA shows e.g. degree_F
+#   - unit_system = METRICWX   -> SI-ish units published, HA shows degree_C, etc.
+#
+# GROUP_TO_DEVICE_CLASS maps a weewx unit group to a Home Assistant
+# (device_class, state_class). Only observations whose group is listed here get a
+# discovery entity. UNIT_TO_HA_UOM maps the weewx unit actually in use to a Home
+# Assistant 'unit_of_measurement' string.
+GROUP_TO_DEVICE_CLASS = {
+    'group_temperature':  ('temperature',             'measurement'),
+    'group_pressure':     ('atmospheric_pressure',    'measurement'),
+    'group_pressurerate': (None,                      'measurement'),
+    'group_rain':         ('precipitation',           'total'),
+    'group_rainrate':     ('precipitation_intensity', 'measurement'),
+    'group_speed':        ('wind_speed',              'measurement'),
+    'group_percent':      (None,                      'measurement'),
+    'group_direction':    (None,                      'measurement'),
+    'group_radiation':    ('irradiance',              'measurement'),
+    'group_distance':     ('distance',                'measurement'),
+    'group_altitude':     ('distance',                'measurement'),
+    'group_volt':         ('voltage',                 'measurement'),
+    'group_power':        ('power',                   'measurement'),
+    'group_energy':       ('energy',                  'total_increasing'),
+    # A timestamp (e.g. dateTime, the time of the observation). state_class must
+    # be None: Home Assistant rejects a state_class on a timestamp entity. The
+    # epoch value is converted to a datetime in the discovery value_template.
+    'group_time':         ('timestamp',               None),
+}
+
+# Map weewx unit names to Home Assistant 'unit_of_measurement' strings. weewx
+# 'mbar' is reported to HA as 'hPa' (numerically identical). Units not listed are
+# sent without a unit_of_measurement.
+UNIT_TO_HA_UOM = {
+    'degree_F': '°F', 'degree_C': '°C', 'degree_K': 'K',
+    'inHg': 'inHg', 'mbar': 'hPa', 'hPa': 'hPa', 'mmHg': 'mmHg', 'kPa': 'kPa',
+    'inHg_per_hour': 'inHg/h', 'mbar_per_hour': 'hPa/h', 'hPa_per_hour': 'hPa/h',
+    'inch': 'in', 'cm': 'cm', 'mm': 'mm',
+    'inch_per_hour': 'in/h', 'cm_per_hour': 'cm/h', 'mm_per_hour': 'mm/h',
+    'mile_per_hour': 'mph', 'km_per_hour': 'km/h', 'meter_per_second': 'm/s',
+    'knot': 'kn',
+    'percent': '%', 'degree_compass': '°',
+    'watt_per_meter_squared': 'W/m²',
+    'volt': 'V', 'watt': 'W', 'watt_hour': 'Wh',
+    'km': 'km', 'meter': 'm', 'mile': 'mi', 'foot': 'ft',
+    'uv_index': None,
+}
+
+# Home Assistant only allows a fixed set of units for each device_class, and
+# rejects the whole discovery message if the unit_of_measurement is not one of
+# them (e.g. 'cm/h' is not valid for 'precipitation_intensity'). For each
+# device_class we use, this lists the units HA accepts. If our published unit is
+# not in the set, we drop the device_class rather than the (correct) unit.
+# Device classes without a unit constraint (e.g. 'timestamp') are not listed.
+DEVICE_CLASS_UNITS = {
+    'temperature':             {'°C', '°F', 'K'},
+    'atmospheric_pressure':    {'cbar', 'bar', 'hPa', 'mmHg', 'inHg', 'kPa',
+                                'mbar', 'Pa', 'psi'},
+    'humidity':                {'%'},
+    'precipitation':           {'cm', 'in', 'mm'},
+    'precipitation_intensity': {'in/d', 'in/h', 'mm/d', 'mm/h'},
+    'wind_speed':              {'Beaufort', 'ft/s', 'km/h', 'kn', 'm/s', 'mph'},
+    'irradiance':              {'W/m²', 'BTU/(h⋅ft²)'},
+    'distance':                {'km', 'm', 'cm', 'mm', 'mi', 'nmi', 'yd',
+                                'in', 'ft'},
+    'voltage':                 {'V', 'mV', 'µV', 'kV', 'MV'},
+    'power':                   {'mW', 'W', 'kW', 'MW', 'GW', 'TW', 'BTU/h'},
+    'energy':                  {'J', 'kJ', 'MJ', 'GJ', 'mWh', 'Wh', 'kWh',
+                                'MWh', 'GWh', 'TWh', 'cal', 'kcal', 'Mcal',
+                                'Gcal'},
+}
+
+# Observations in group_percent that really represent relative humidity. These
+# get the Home Assistant 'humidity' device_class; other percentages do not.
+HUMIDITY_OBS = {'outHumidity', 'inHumidity', 'humidity'}
+
+# Record keys that carry no real observation and must never become a sensor. The
+# admin can exclude further fields with the 'skip_fields' option; these are always
+# excluded regardless. (dateTime is intentionally NOT here: it is published as a
+# proper timestamp entity, see group_time above.)
+DEFAULT_SKIP_FIELDS = {'interval', 'usUnits'}
+
+# Friendly display names for common observations. Anything not listed falls back
+# to a humanized version of the weewx key (e.g. 'extraTemp1' -> 'Extra Temp 1').
+OBS_FRIENDLY_NAMES = {
+    'outTemp': 'Outside Temperature', 'inTemp': 'Inside Temperature',
+    'outHumidity': 'Outside Humidity', 'inHumidity': 'Inside Humidity',
+    'barometer': 'Barometer', 'pressure': 'Pressure', 'altimeter': 'Altimeter',
+    'windSpeed': 'Wind Speed', 'windGust': 'Wind Gust',
+    'windDir': 'Wind Direction', 'windGustDir': 'Wind Gust Direction',
+    'rain': 'Rain', 'rainRate': 'Rain Rate', 'dewpoint': 'Dew Point',
+    'windchill': 'Wind Chill', 'heatindex': 'Heat Index',
+    'radiation': 'Solar Radiation', 'UV': 'UV Index',
+    'ET': 'Evapotranspiration', 'appTemp': 'Apparent Temperature',
+    # 'dateTime' is the time of the observation. Give it a descriptive name and
+    # id so it does not show up in Home Assistant as a generic "Date Time" that
+    # clashes with the many unrelated dateTime/timestamp entities other devices
+    # publish.
+    'dateTime': 'Observation Time',
+}
+
+# A few observations get a more descriptive id (used for unique_id/object_id, and
+# hence the Home Assistant entity_id) than their terse weewx key.
+OBS_ID_OVERRIDES = {'dateTime': 'observation_time'}
+
+
+def _friendly_name(obs):
+    """Return a human-friendly name for an observation key."""
+    if obs in OBS_FRIENDLY_NAMES:
+        return OBS_FRIENDLY_NAMES[obs]
+    # Insert spaces at camelCase and letter/digit boundaries, then title-case.
+    s = re.sub('([a-z])([A-Z])', r'\1 \2', obs)
+    s = re.sub('([A-Za-z])([0-9])', r'\1 \2', s)
+    s = s.replace('_', ' ')
+    return s[:1].upper() + s[1:]
 
 
 class MQTT(weewx.restx.StdRESTbase):
@@ -300,6 +424,39 @@ class MQTT(weewx.restx.StdRESTbase):
         except weewx.UnknownBinding:
             pass
 
+        # Optional Home Assistant MQTT discovery. The nested [[[ha_discovery]]]
+        # section is not part of the accumulated site_dict, so read it directly.
+        mqtt_cfg = config_dict['StdRESTful']['MQTT']
+        if 'ha_discovery' in mqtt_cfg and to_bool(mqtt_cfg['ha_discovery'].get('enable', False)):
+            ha_cfg = mqtt_cfg['ha_discovery']
+            device_cfg = ha_cfg.get('device', {})
+            stn = getattr(self.engine, 'stn_info', None)
+            # 'skip_fields' lists observations that get no discovery message.
+            # They are still published as normal MQTT data; only the HA discovery
+            # announcement is suppressed.
+            # ConfigObj gives a string for a single value or a list for several.
+            skip_fields = ha_cfg.get('skip_fields', [])
+            if isinstance(skip_fields, str):
+                skip_fields = [skip_fields]
+            site_dict['ha_discovery'] = {
+                'enable': True,
+                'discovery_prefix': ha_cfg.get('discovery_prefix', 'homeassistant'),
+                'node_id': ha_cfg.get('node_id', 'weewx'),
+                'unique_id_prefix': ha_cfg.get('unique_id_prefix', 'weewx'),
+                'skip_fields': skip_fields,
+                'device': {
+                    'name': device_cfg.get('name',
+                                           getattr(stn, 'location', None) or 'WeeWX'),
+                    'manufacturer': device_cfg.get('manufacturer', 'WeeWX'),
+                    'model': device_cfg.get('model',
+                                            getattr(stn, 'hardware', None) or 'Unknown'),
+                    'identifiers': device_cfg.get('identifiers',
+                                                  ha_cfg.get('node_id', 'weewx')),
+                    'sw_version': weewx.__version__,
+                },
+            }
+            loginf("Home Assistant discovery is enabled")
+
         self.archive_queue = Queue.Queue()
         self.archive_thread = MQTTThread(self.archive_queue, **site_dict)
         self.archive_thread.start()
@@ -387,6 +544,7 @@ class MQTTThread(weewx.restx.RESTThread):
                  augment_record=True, retain=False, aggregation='individual',
                  inputs={}, obs_to_upload='all', append_units_label=True,
                  manager_dict=None, tls=None, qos=0,
+                 ha_discovery=None,
                  post_interval=None, stale=None,
                  log_success=True, log_failure=True,
                  timeout=60, max_tries=3, retry_wait=5,
@@ -426,11 +584,39 @@ class MQTTThread(weewx.restx.RESTThread):
         self.augment_record = augment_record
         self.retain = retain
         self.qos = qos
+        # ConfigObj parses a comma-separated 'aggregation' (e.g. "individual,
+        # aggregate") into a list; normalize to a string so .find() works.
+        if not isinstance(aggregation, str):
+            aggregation = ','.join(aggregation)
         self.aggregation = aggregation
         self.templates = dict()
         self.skip_upload = skip_upload
         self.mc = None
         self.mc_try_time = 0
+        # Home Assistant discovery: config dict (or empty) and a one-time guard.
+        self.ha = ha_discovery or {}
+        device = self.ha.get('device')
+        if device:
+            # ConfigObj turns any comma-containing value (e.g. a location like
+            # "Bronx, New York") into a list, but Home Assistant requires
+            # these device fields to be plain strings -- it rejects the whole
+            # discovery message otherwise. Coerce them.
+            for key in ('name', 'manufacturer', 'model', 'sw_version'):
+                if isinstance(device.get(key), (list, tuple)):
+                    device[key] = ', '.join(str(x) for x in device[key])
+            # 'identifiers' must be a list of strings.
+            ident = device.get('identifiers')
+            if isinstance(ident, str):
+                device['identifiers'] = [ident]
+            elif isinstance(ident, (list, tuple)):
+                device['identifiers'] = [str(x) for x in ident]
+        # Fields excluded from discovery: the mandatory non-observations plus any
+        # the admin configured via 'skip_fields'.
+        self.skip_fields = set(DEFAULT_SKIP_FIELDS) | set(self.ha.get('skip_fields', []))
+        self._discovery_sent = False
+        # Latches the "no usUnits" warning so a station that never emits it logs
+        # once, not on every record.
+        self._warned_no_usunits = False
 
     def get_mqtt_client(self):
         if self.mc:
@@ -508,7 +694,161 @@ class MQTTThread(weewx.restx.RESTThread):
             data['position'] = ','.join(parts)
         return data
 
+    def _published_name_and_unit(self, obs, usUnits):
+        """Return (published_name, weewx_unit) for an observation, matching exactly
+        what filter_data() publishes: this honors append_units_label and any
+        per-input 'name'/'unit' override, so the discovery state_topic/value_template
+        line up with the data that is actually sent."""
+        overrides = self.inputs.get(obs, {})
+        tmpl = _get_template(obs, overrides, self.append_units_label, usUnits)
+        name = tmpl.get('name', obs)
+        unit = tmpl.get('unit')
+        if unit is None:
+            try:
+                (unit, _group) = weewx.units.getStandardUnitType(usUnits, obs)
+            except (KeyError, ValueError):
+                unit = None
+        return name, unit
+
+    def _discovery_configs(self, record):
+        """Build (config_topic, payload) pairs for Home Assistant discovery.
+
+        A sensor is produced for each *published* observation whose unit group is
+        known (GROUP_TO_DEVICE_CLASS) and that is not excluded by skip_fields. The
+        reported units are those of the data as actually published -- i.e. after
+        any 'unit_system' conversion -- so Home Assistant shows whatever units the
+        station or admin chose. In aggregate mode the sensor reads the JSON loop
+        packet via a value_template; otherwise it reads the field's own sub-topic.
+        """
+        configs = []
+        # Units are interpreted via usUnits. If a record lacks it,
+        # getStandardUnitType() below returns (None, None) and every observation
+        # is skipped, so this naturally yields no configs. The caller decides what
+        # to do with an empty result (warn and retry on a later record).
+        usUnits = record.get('usUnits')
+        prefix = self.ha.get('discovery_prefix', 'homeassistant')
+        node = self.ha.get('node_id', 'weewx')
+        uid_prefix = self.ha.get('unique_id_prefix', 'weewx')
+        device = self.ha.get('device', {})
+        aggregate = self.aggregation.find('aggregate') >= 0
+        # Mirror filter_data's choice of which observations get published.
+        candidates = record if self.upload_all else self.inputs
+        for obs in candidates:
+            if obs in self.skip_fields or obs not in record or record.get(obs) is None:
+                continue
+            try:
+                float(record.get(obs))
+            except (TypeError, ValueError):
+                continue
+            try:
+                (_u, group) = weewx.units.getStandardUnitType(usUnits, obs)
+            except (KeyError, ValueError):
+                continue
+            if group not in GROUP_TO_DEVICE_CLASS:
+                continue
+            device_class, state_class = GROUP_TO_DEVICE_CLASS[group]
+            if group == 'group_percent' and obs in HUMIDITY_OBS:
+                device_class = 'humidity'
+            name, unit = self._published_name_and_unit(obs, usUnits)
+            uom = UNIT_TO_HA_UOM.get(unit)
+            # HA validates the unit against the device_class and rejects the whole
+            # entity on a mismatch (e.g. 'cm/h' is not valid for
+            # 'precipitation_intensity' when unit_system=METRIC). The unit is the
+            # truth, so keep it and drop the device_class instead -- the sensor is
+            # then a plain measurement with the correct unit.
+            if (device_class in DEVICE_CLASS_UNITS
+                    and uom not in DEVICE_CLASS_UNITS[device_class]):
+                logdbg("HA discovery: unit %r not valid for device_class %r on "
+                       "%s; publishing without a device_class"
+                       % (uom, device_class, obs))
+                device_class = None
+            obs_id = OBS_ID_OVERRIDES.get(obs, obs)
+            is_timestamp = device_class == 'timestamp'
+            payload = {
+                'name': _friendly_name(obs),
+                'unique_id': "%s_%s" % (uid_prefix, obs_id),
+                'object_id': "%s_%s" % (uid_prefix, obs_id),
+                'device': device,
+            }
+            # Home Assistant forbids a state_class on a timestamp entity, so only
+            # set it when present.
+            if state_class is not None:
+                payload['state_class'] = state_class
+            if uom is not None:
+                payload['unit_of_measurement'] = uom
+            if device_class is not None:
+                payload['device_class'] = device_class
+            # Where the sensor reads its state, and the expression for the value.
+            if aggregate:
+                payload['state_topic'] = self.topic + '/loop'
+                src = "value_json.%s" % name
+            else:
+                payload['state_topic'] = self.topic + '/' + name
+                src = "value"
+            # A timestamp is published as a Unix epoch, but HA's timestamp
+            # device_class needs a datetime, so convert it. Other fields need a
+            # template only in aggregate mode (to pull the value out of the JSON);
+            # in individual mode the raw payload already is the value.
+            if is_timestamp:
+                payload['value_template'] = "{{ as_datetime(%s | float) }}" % src
+            elif aggregate:
+                payload['value_template'] = "{{ %s }}" % src
+            topic = "%s/sensor/%s/%s/config" % (prefix, node, obs)
+            configs.append((topic, payload))
+        return configs
+
+    def publish_ha_discovery(self, record):
+        """Publish Home Assistant discovery configs (retained). Used both for the
+        automatic once-before-first-packet trigger and the manual admin trigger
+        (weectl rest run --discovery)."""
+        if not self.ha.get('enable'):
+            loginf("Home Assistant discovery is not enabled")
+            return
+        # Every observation's units are interpreted via the record's usUnits.
+        # Some records may not carry it; without it the data cannot be described,
+        # so skip *without* marking discovery as sent, leaving it to be retried on
+        # a later record that does have usUnits.
+        if record.get('usUnits') is None:
+            logerr("Home Assistant discovery skipped: record has no 'usUnits'; "
+                   "cannot determine units. Will retry on a later record.")
+            return
+        # Describe the data as it will actually be published: honor unit_system.
+        # (Idempotent when process_record already converted the record.)
+        if self.unit_system is not None:
+            record = weewx.units.to_std_system(record, self.unit_system)
+        configs = self._discovery_configs(record)
+        if not configs:
+            logdbg("Home Assistant discovery: record has no describable "
+                   "observations; will retry on a later record.")
+            return
+        self.get_mqtt_client()
+        if not self.mc:
+            raise weewx.restx.FailedPost('MQTT client not available')
+        for topic, payload in configs:
+            (res, mid) = self.mc.publish(topic, json.dumps(payload),
+                                         retain=True, qos=self.qos)
+            if res != mqtt.MQTT_ERR_SUCCESS:
+                logerr("HA discovery publish failed for %s: %s" %
+                       (topic, mqtt.error_string(res)))
+        loginf("published Home Assistant discovery for %d sensors" % len(configs))
+        # Only now do we consider discovery done, so a first record that could not
+        # be described does not permanently suppress it.
+        self._discovery_sent = True
+
     def process_record(self, record, dbm):
+        # Augmenting, converting and labeling all interpret the data via usUnits,
+        # which is a WeeWX invariant: every loop packet and archive record carries
+        # it. A record without it cannot be processed, so skip it instead of
+        # raising KeyError -- which would kill the posting thread -- or publishing
+        # unitless, inconsistent topics. We warn only once so a misbehaving source
+        # that never emits usUnits does not flood the log every record.
+        if record.get('usUnits') is None:
+            if not self._warned_no_usunits:
+                logerr("skipping record(s) with no 'usUnits': cannot determine "
+                       "units. weewx-mqtt requires usUnits on every record.")
+                self._warned_no_usunits = True
+            return
+        self._warned_no_usunits = False
         if self.augment_record and dbm is not None:
             record = self.get_record(record, dbm)
         if self.unit_system is not None:
@@ -522,6 +862,9 @@ class MQTTThread(weewx.restx.RESTThread):
         self.get_mqtt_client()
         if not self.mc:
             raise weewx.restx.FailedPost('MQTT client not available')
+        # Publish Home Assistant discovery once, before the first data packet.
+        if self.ha.get('enable') and not self._discovery_sent:
+            self.publish_ha_discovery(record)
         if self.aggregation.find('aggregate') >= 0:
             tpc = self.topic + '/loop'
             (res, mid) = self.mc.publish(tpc, json.dumps(data),

--- a/bin/user/tests/fakes.py
+++ b/bin/user/tests/fakes.py
@@ -1,0 +1,135 @@
+#
+# Copyright 2024 - Distributed under the terms of the GNU Public License (GPLv3)
+#
+"""Broker-free stand-ins for a paho MQTT client, shared by the test modules.
+
+FakeClient replaces an already-connected client (assign it to MQTTThread.mc).
+FakePahoClient replaces the paho Client *class*, so the connection setup in
+MQTTThread._new_client can be exercised without a broker.
+"""
+import os
+import sys
+
+# Make 'import mqtt' work whether or not the extension is installed as user.mqtt.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import mqtt  # noqa: E402
+
+
+class FakeMessageInfo:
+    """Stand-in for paho's MQTTMessageInfo.
+
+    Mirrors the real class where MQTTThread depends on it: wait_for_publish
+    raises RuntimeError rather than returning when the message can no longer be
+    delivered, and returns normally (leaving is_published() False) on timeout.
+    """
+
+    def __init__(self, rc=None, published=True):
+        self.rc = mqtt.mqtt.MQTT_ERR_SUCCESS if rc is None else rc
+        self.mid = 1
+        self._published = published
+        self.waited = False
+
+    def wait_for_publish(self, timeout=None):
+        self.waited = True
+        if self.rc > 0:
+            raise RuntimeError('Message publish failed: %s'
+                               % mqtt.mqtt.error_string(self.rc))
+
+    def is_published(self):
+        return self._published
+
+
+class FakeClient:
+    """A connected client that records what was published.
+
+    publish_rc -- error code publish() should return instead of success
+    confirmed  -- whether the broker acknowledges published messages
+    connected  -- what is_connected() reports
+    """
+
+    def __init__(self, publish_rc=None, confirmed=True, connected=True):
+        self.published = []
+        self.infos = []
+        self.publish_rc = publish_rc
+        self.confirmed = confirmed
+        self.connected = connected
+        self.disconnected = False
+        self.loop_stopped = False
+
+    def is_connected(self):
+        return self.connected
+
+    def publish(self, topic, payload=None, retain=False, qos=0):
+        self.published.append((topic, payload, retain, qos))
+        info = FakeMessageInfo(self.publish_rc, self.confirmed)
+        self.infos.append(info)
+        return info
+
+    def disconnect(self):
+        self.disconnected = True
+        self.connected = False
+
+    def loop_stop(self):
+        self.loop_stopped = True
+
+
+class FakePahoClient(FakeClient):
+    """Stand-in for the paho Client class itself.
+
+    Patch it over mqtt.mqtt.Client so MQTTThread._new_client runs its real
+    callback wiring. Class attributes control what the "broker" does:
+
+    connack_rc -- reason code delivered to on_connect; None means no CONNACK
+                  ever arrives, which is how a connect timeout is simulated
+    """
+    connack_rc = 0
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        super(FakePahoClient, self).__init__(connected=False)
+        self.client_id = kwargs.get('client_id')
+        self.connect_args = None
+        self.reconnect_delays = None
+        self.credentials = None
+        self.tls_args = None
+        self.on_connect = None
+        self.on_disconnect = None
+        FakePahoClient.instances.append(self)
+
+    @classmethod
+    def reset(cls, connack_rc=0):
+        cls.connack_rc = connack_rc
+        cls.instances = []
+
+    def reconnect_delay_set(self, min_delay=None, max_delay=None):
+        self.reconnect_delays = (min_delay, max_delay)
+
+    def username_pw_set(self, username, password=None):
+        self.credentials = (username, password)
+
+    def tls_set(self, **kwargs):
+        self.tls_args = kwargs
+
+    def connect(self, host, port, keepalive=60):
+        self.connect_args = (host, port, keepalive)
+
+    def loop_start(self):
+        # A real client receives the CONNACK on its network thread, after
+        # connect() has returned; fire the callback from here to match.
+        if self.connack_rc is None:
+            return
+        self.connected = (self.connack_rc == 0)
+        self.fire_connect(self.connack_rc)
+
+    def fire_connect(self, rc):
+        if mqtt.PAHO2:
+            self.on_connect(self, None, {}, rc, None)
+        else:
+            self.on_connect(self, None, {}, rc)
+
+    def fire_disconnect(self, rc):
+        self.connected = False
+        if mqtt.PAHO2:
+            self.on_disconnect(self, None, {}, rc, None)
+        else:
+            self.on_disconnect(self, None, rc)

--- a/bin/user/tests/test_mqtt_connection.py
+++ b/bin/user/tests/test_mqtt_connection.py
@@ -1,0 +1,365 @@
+#
+# Copyright 2024 - Distributed under the terms of the GNU Public License (GPLv3)
+#
+"""Broker-free tests for connection handling in user.mqtt.
+
+These cover the failure that motivated the work: once the connection to the
+broker was lost, the cached client was never checked or rebuilt, so every
+subsequent publish failed with "The client is not currently connected" until
+weewx was restarted -- and the failure was only logged, never reported, so weewx
+logged a successful post on top of the lost record.
+
+Run from the extension root:
+    PYTHONPATH=/path/to/weewx/src python bin/user/tests/test_mqtt_connection.py
+"""
+import os
+import sys
+import time
+import unittest
+
+try:
+    import queue as Queue
+except ImportError:
+    import Queue
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import mqtt  # noqa: E402
+from fakes import FakeClient, FakePahoClient  # noqa: E402
+
+import weewx  # noqa: E402
+import weewx.restx  # noqa: E402
+
+
+RECORD = {
+    'dateTime': 1781339400, 'usUnits': weewx.US, 'interval': 30,
+    'outTemp': 61.0, 'outHumidity': 78.0, 'barometer': 29.95,
+}
+
+NO_CONN = mqtt.mqtt.MQTT_ERR_NO_CONN
+
+
+def make_thread(**kwargs):
+    opts = dict(server_url='mqtt://localhost:1883/', topic='weather',
+                aggregation='individual,aggregate',
+                # Keep the tests fast: no waiting between retries, and short
+                # timeouts on the paths that are supposed to time out.
+                retry_wait=0, connect_timeout=0.05, publish_timeout=0.05)
+    opts.update(kwargs)
+    return mqtt.MQTTThread(Queue.Queue(), **opts)
+
+
+class EnsureClientTest(unittest.TestCase):
+    """_ensure_client must hand back a *connected* client, or build a new one.
+
+    The original code only checked that the client object existed, which is why
+    a dead connection was never noticed.
+    """
+
+    def setUp(self):
+        # A live client recovers well inside this; shrink it so the tests that
+        # exercise a dead client do not sit through the real grace period.
+        self.grace = mqtt.RECONNECT_GRACE
+        mqtt.RECONNECT_GRACE = 0.01
+
+    def tearDown(self):
+        mqtt.RECONNECT_GRACE = self.grace
+
+    def test_connected_client_is_reused(self):
+        t = make_thread()
+        t.mc = FakeClient(connected=True)
+        t._new_client = lambda: self.fail('should not have rebuilt the client')
+        self.assertIs(t._ensure_client(), t.mc)
+
+    def test_disconnected_client_is_torn_down_and_rebuilt(self):
+        t = make_thread()
+        dead = FakeClient(connected=False)
+        t.mc = dead
+        fresh = FakeClient(connected=True)
+
+        def rebuild():
+            t.mc = fresh
+            return fresh
+        t._new_client = rebuild
+
+        self.assertIs(t._ensure_client(), fresh)
+        self.assertTrue(dead.disconnected, 'dead client should be disconnected')
+        self.assertTrue(dead.loop_stopped, 'dead client loop should be stopped')
+
+    def test_client_reconnecting_on_its_own_is_kept(self):
+        # If the client's own reconnect lands within the grace period there is
+        # no reason to throw it away.
+        t = make_thread()
+
+        class Reconnecting(FakeClient):
+            """Not connected when first asked, connected a moment later."""
+            def is_connected(inner):
+                was = inner.connected
+                inner.connected = True
+                t._connected.set()
+                return was
+
+        t.mc = Reconnecting(connected=False)
+        t._new_client = lambda: self.fail('should not have rebuilt the client')
+        self.assertIs(t._ensure_client(), t.mc)
+
+    def test_client_that_only_claims_to_be_connected_is_rebuilt(self):
+        # A stale connected flag must not get a dead client past the check;
+        # the client's own view of the socket is what counts.
+        t = make_thread()
+        dead = FakeClient(connected=False)
+        t.mc = dead
+        t._connected.set()
+        fresh = FakeClient()
+        t._new_client = lambda: fresh
+        self.assertIs(t._ensure_client(), fresh)
+        self.assertTrue(dead.disconnected)
+
+    def test_missing_client_is_built(self):
+        t = make_thread()
+        fresh = FakeClient()
+        t._new_client = lambda: fresh
+        self.assertIs(t._ensure_client(), fresh)
+
+
+class ConnectTest(unittest.TestCase):
+    """_new_client must wait for the broker to accept the connection.
+
+    connect() only opens the socket and sends CONNECT; the original code cached
+    the client without waiting for the CONNACK, so a refused connection looked
+    identical to a good one until a publish failed much later.
+    """
+
+    def setUp(self):
+        self.real_client = mqtt.mqtt.Client
+        mqtt.mqtt.Client = FakePahoClient
+        FakePahoClient.reset()
+
+    def tearDown(self):
+        mqtt.mqtt.Client = self.real_client
+        FakePahoClient.reset()
+
+    def test_successful_connect(self):
+        t = make_thread()
+        mc = t._new_client()
+        self.assertIs(t.mc, mc)
+        self.assertTrue(t._connected.is_set())
+        self.assertEqual(mc.connect_args, ('localhost', 1883, t.keepalive))
+        self.assertEqual(mc.reconnect_delays,
+                         (t.reconnect_min_delay, t.reconnect_max_delay))
+
+    def test_no_connack_times_out_and_tears_down(self):
+        FakePahoClient.reset(connack_rc=None)   # broker never answers
+        t = make_thread()
+        with self.assertRaises(weewx.restx.FailedPost) as cm:
+            t._new_client()
+        self.assertIn('timed out', str(cm.exception))
+        self.assertIsNone(t.mc, 'a client that never connected must not be kept')
+        self.assertTrue(FakePahoClient.instances[0].loop_stopped)
+
+    def test_refused_connection_reports_the_reason(self):
+        FakePahoClient.reset(connack_rc=5)      # not authorised
+        t = make_thread()
+        with self.assertRaises(weewx.restx.FailedPost) as cm:
+            t._new_client()
+        self.assertIn('refused', str(cm.exception))
+        self.assertIn('authoris', str(cm.exception).lower())
+        self.assertIsNone(t.mc)
+
+    def test_refused_connection_fails_immediately(self):
+        # A refusal is final, so there is nothing to wait for. Waiting out
+        # connect_timeout would only let the client retry in the background and
+        # fill the log with the same refusal several times over.
+        FakePahoClient.reset(connack_rc=5)
+        t = make_thread(connect_timeout=30)
+        started = time.time()
+        with self.assertRaises(weewx.restx.FailedPost):
+            t._new_client()
+        self.assertLess(time.time() - started, 1.0)
+
+    def test_credentials_and_port_from_url(self):
+        t = make_thread(server_url='mqtt://bob:secret@broker.example:1884/')
+        mc = t._new_client()
+        self.assertEqual(mc.credentials, ('bob', 'secret'))
+        self.assertEqual(mc.connect_args[:2], ('broker.example', 1884))
+
+    def test_tls_defaults_to_port_8883(self):
+        t = make_thread(server_url='mqtts://broker.example/',
+                        tls={'tls_version': 'tlsv12'})
+        mc = t._new_client()
+        self.assertEqual(mc.connect_args[1], 8883)
+        self.assertIsNotNone(mc.tls_args)
+
+    def test_password_is_not_leaked_in_errors(self):
+        FakePahoClient.reset(connack_rc=None)
+        t = make_thread(server_url='mqtt://bob:hunter2@broker.example:1883/')
+        with self.assertRaises(weewx.restx.FailedPost) as cm:
+            t._new_client()
+        self.assertNotIn('hunter2', str(cm.exception))
+
+
+class CallbackTest(unittest.TestCase):
+    """The connect/disconnect callbacks are the only warning of an outage."""
+
+    def test_disconnect_clears_connected_state(self):
+        t = make_thread()
+        t._connected.set()
+        t._on_disconnect(NO_CONN)
+        self.assertFalse(t._connected.is_set())
+
+    def test_connect_sets_state_and_reannounces_discovery(self):
+        # A broker that came back without its retained store would leave Home
+        # Assistant with no discovery configs, so a reconnect re-announces them.
+        t = make_thread()
+        t._discovery_sent = True
+        t._on_connect(0)
+        self.assertTrue(t._connected.is_set())
+        self.assertFalse(t._discovery_sent)
+
+    def test_refused_connect_leaves_state_clear(self):
+        t = make_thread()
+        t._on_connect(5)
+        self.assertFalse(t._connected.is_set())
+        self.assertEqual(t._connect_rc, 5)
+
+
+class ReasonCodeTest(unittest.TestCase):
+    """paho 1.x reports result codes as ints, paho 2.x as ReasonCode objects.
+    error_string() renders the latter as "Unknown error.", which would hide the
+    one detail that matters most in a disconnect log."""
+
+    def test_int_result_code(self):
+        self.assertEqual(mqtt._rc_string(mqtt.mqtt.MQTT_ERR_NO_CONN),
+                         'The client is not currently connected.')
+
+    @unittest.skipUnless(mqtt.PAHO2, 'requires paho-mqtt 2.x')
+    def test_reason_code_object(self):
+        from paho.mqtt.reasoncodes import ReasonCode
+        # 142 is "Session taken over": what a broker sends when a second client
+        # connects with the same client_id and evicts this one.
+        rc = ReasonCode(mqtt.mqtt.DISCONNECT >> 4, identifier=142)
+        self.assertEqual(mqtt._rc_string(rc), 'Session taken over')
+
+
+class RetryTest(unittest.TestCase):
+    """A failed publish must be retried on a fresh connection, and a record that
+    cannot be delivered at all must be reported to weewx as a failure."""
+
+    def _clients(self, t, *clients):
+        """Hand out the given clients in order as the thread rebuilds."""
+        queue = list(clients)
+
+        def build():
+            t.mc = queue.pop(0)
+            return t.mc
+        t._new_client = build
+        return queue
+
+    def test_retry_succeeds_on_a_fresh_connection(self):
+        t = make_thread()
+        dead = FakeClient(publish_rc=NO_CONN)
+        good = FakeClient()
+        remaining = self._clients(t, dead, good)
+
+        t.process_record(dict(RECORD), None)    # must not raise
+
+        self.assertEqual(remaining, [], 'both clients should have been used')
+        self.assertTrue(good.published, 'the record should land on the new client')
+        self.assertTrue(dead.disconnected,
+                        'the failed client must be discarded, not reused')
+
+    def test_failure_is_reported_after_max_tries(self):
+        # The original code only logged this, so weewx went on to log a
+        # successful post for a record that was never delivered.
+        t = make_thread(max_tries=3)
+        clients = [FakeClient(publish_rc=NO_CONN) for _ in range(3)]
+        remaining = self._clients(t, *clients)
+
+        with self.assertRaises(weewx.restx.FailedPost) as cm:
+            t.process_record(dict(RECORD), None)
+        self.assertIn('3 attempts', str(cm.exception))
+        self.assertEqual(remaining, [], 'should have tried max_tries times')
+        self.assertIsNone(t.mc)
+
+    def test_failed_attempt_publishes_no_duplicates(self):
+        # At qos >= 1 a client holds a message published while disconnected and
+        # redelivers it on reconnect. Discarding the client is what keeps the
+        # retry from delivering every observation twice.
+        t = make_thread()
+        dead = FakeClient(publish_rc=NO_CONN)
+        good = FakeClient()
+        self._clients(t, dead, good)
+
+        t.process_record(dict(RECORD), None)
+
+        self.assertTrue(dead.disconnected)
+        topics = [p[0] for p in good.published]
+        self.assertEqual(len(topics), len(set(topics)), 'no topic twice')
+
+    def test_unconfirmed_delivery_is_a_failure(self):
+        # publish() succeeding only means the message was handed to the client;
+        # at qos >= 1 the broker's acknowledgement is the real evidence.
+        t = make_thread(max_tries=1)
+        self._clients(t, FakeClient(confirmed=False))
+        with self.assertRaises(weewx.restx.FailedPost) as cm:
+            t.process_record(dict(RECORD), None)
+        self.assertIn('confirm', str(cm.exception))
+
+    def test_connection_failure_is_retried(self):
+        t = make_thread(max_tries=2)
+        attempts = []
+
+        def build():
+            attempts.append(1)
+            if len(attempts) < 2:
+                raise weewx.restx.FailedPost('broker down')
+            t.mc = FakeClient()
+            return t.mc
+        t._new_client = build
+
+        t.process_record(dict(RECORD), None)    # must not raise
+        self.assertEqual(len(attempts), 2)
+
+
+class QosTest(unittest.TestCase):
+    """The configured qos applies to every message. Individual observations
+    previously ignored it and were always published at qos 0."""
+
+    def test_individual_publishes_honor_configured_qos(self):
+        t = make_thread(qos=2)
+        c = FakeClient()
+        t._new_client = lambda: c
+        t.mc = c
+        t.process_record(dict(RECORD), None)
+
+        individual = [p for p in c.published if not p[0].endswith('/loop')]
+        self.assertTrue(individual)
+        for topic, _payload, _retain, qos in c.published:
+            self.assertEqual(qos, 2, 'wrong qos on %s' % topic)
+
+    def test_default_qos_is_at_least_once(self):
+        # At qos 0 anything published while the connection is down is silently
+        # dropped, which loses the record outright.
+        self.assertEqual(make_thread().qos, 1)
+
+    def test_qos_zero_skips_delivery_confirmation(self):
+        # Nothing is acknowledged at qos 0, so there is nothing to wait for.
+        t = make_thread(qos=0)
+        c = FakeClient(confirmed=False)
+        t._new_client = lambda: c
+        t.mc = c
+        t.process_record(dict(RECORD), None)    # must not raise
+        self.assertTrue(c.infos)
+        self.assertFalse(any(i.waited for i in c.infos))
+
+
+class SkipUploadTest(unittest.TestCase):
+
+    def test_skip_upload_touches_no_connection(self):
+        t = make_thread(skip_upload=True)
+        t._new_client = lambda: self.fail('should not have connected')
+        t.process_record(dict(RECORD), None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bin/user/tests/test_mqtt_discovery.py
+++ b/bin/user/tests/test_mqtt_discovery.py
@@ -1,0 +1,350 @@
+#
+# Copyright 2024 - Distributed under the terms of the GNU Public License (GPLv3)
+#
+"""Broker-free tests for the Home Assistant discovery support in user.mqtt.
+
+These tests exercise discovery payload generation, the reuse of the 'unit_system'
+option to drive unit conversion, the configurable 'skip_fields' option, and the
+once-before-first-packet trigger -- all without needing a live MQTT broker.
+
+Run from the extension root:
+    PYTHONPATH=/path/to/weewx/src python bin/user/tests/test_mqtt_discovery.py
+"""
+import copy
+import os
+import sys
+import unittest
+
+try:
+    import queue as Queue
+except ImportError:
+    import Queue
+
+# Make 'import mqtt' work whether or not the extension is installed as user.mqtt.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import mqtt  # noqa: E402
+
+import weewx  # noqa: E402
+
+
+# A record exactly as a US-units station reports it (weewx keys, usUnits == US).
+US_RECORD = {
+    'dateTime': 1781339400, 'usUnits': weewx.US, 'interval': 30,
+    'outTemp': 61.0, 'inTemp': 78.7, 'outHumidity': 78.0, 'inHumidity': 39.0,
+    'barometer': 29.95, 'rain': 0.0, 'rainRate': 0.0,
+    'windSpeed': 2.0, 'windGust': 9.0, 'windDir': 90.0,
+}
+
+# The same conditions reported by a METRICWX station, to prove discovery reflects
+# whatever units are actually in the record (not an assumed US source).
+METRICWX_RECORD = {
+    'dateTime': 1781339400, 'usUnits': weewx.METRICWX, 'interval': 30,
+    'outTemp': 16.1111, 'outHumidity': 78.0, 'barometer': 1014.2,
+    'windSpeed': 0.8941, 'windDir': 90.0,
+}
+
+HA_DISCOVERY = {
+    'enable': True,
+    'discovery_prefix': 'homeassistant',
+    'node_id': 'weewx',
+    'unique_id_prefix': 'weewx',
+    'skip_fields': [],
+    'device': {'name': 'Test Station', 'manufacturer': 'WeeWX',
+               'model': 'Simulator', 'identifiers': 'weewx', 'sw_version': '5.x'},
+}
+
+
+def make_thread(ha=None, **kwargs):
+    # Mirror the MQTT service's default aggregation ('individual,aggregate'); the
+    # MQTTThread class default on its own is just 'individual'.
+    opts = dict(server_url='mqtt://localhost:1883/', topic='weather',
+                aggregation='individual,aggregate',
+                ha_discovery=copy.deepcopy(HA_DISCOVERY if ha is None else ha))
+    opts.update(kwargs)
+    return mqtt.MQTTThread(Queue.Queue(), **opts)
+
+
+class FakeClient:
+    """Minimal stand-in for a paho client that records what was published."""
+    def __init__(self):
+        self.published = []
+
+    def publish(self, topic, payload=None, retain=False, qos=0):
+        self.published.append((topic, payload, retain))
+        return (mqtt.mqtt.MQTT_ERR_SUCCESS, 1)
+
+
+class DiscoveryUnitsTest(unittest.TestCase):
+    """Discovery must describe the data in whatever units the record carries."""
+
+    def test_native_us_units(self):
+        configs = dict(make_thread()._discovery_configs(US_RECORD))
+        t = configs['homeassistant/sensor/weewx/outTemp/config']
+        self.assertEqual(t['device_class'], 'temperature')
+        self.assertEqual(t['unit_of_measurement'], '°F')
+        self.assertEqual(t['value_template'], '{{ value_json.outTemp_F }}')
+        self.assertEqual(t['state_topic'], 'weather/loop')
+        p = configs['homeassistant/sensor/weewx/barometer/config']
+        self.assertEqual(p['device_class'], 'atmospheric_pressure')
+        self.assertEqual(p['unit_of_measurement'], 'inHg')
+
+    def test_metricwx_units(self):
+        configs = dict(make_thread()._discovery_configs(METRICWX_RECORD))
+        t = configs['homeassistant/sensor/weewx/outTemp/config']
+        self.assertEqual(t['unit_of_measurement'], '°C')
+        self.assertEqual(t['value_template'], '{{ value_json.outTemp_C }}')
+        p = configs['homeassistant/sensor/weewx/barometer/config']
+        self.assertEqual(p['unit_of_measurement'], 'hPa')
+        w = configs['homeassistant/sensor/weewx/windSpeed/config']
+        self.assertEqual(w['unit_of_measurement'], 'm/s')
+        self.assertEqual(w['device_class'], 'wind_speed')
+
+    def test_humidity_device_class(self):
+        configs = dict(make_thread()._discovery_configs(US_RECORD))
+        p = configs['homeassistant/sensor/weewx/outHumidity/config']
+        self.assertEqual(p['device_class'], 'humidity')
+        self.assertEqual(p['unit_of_measurement'], '%')
+
+    def test_individual_mode_uses_published_subtopic(self):
+        configs = dict(make_thread(aggregation='individual')._discovery_configs(US_RECORD))
+        p = configs['homeassistant/sensor/weewx/windSpeed/config']
+        self.assertEqual(p['state_topic'], 'weather/windSpeed_mph')
+        self.assertNotIn('value_template', p)
+
+    def test_device_block(self):
+        configs = dict(make_thread()._discovery_configs(US_RECORD))
+        dev = configs['homeassistant/sensor/weewx/outTemp/config']['device']
+        self.assertEqual(dev['name'], 'Test Station')
+        self.assertEqual(dev['identifiers'], ['weewx'])
+
+    def test_list_valued_device_fields_coerced_to_strings(self):
+        # ConfigObj turns "Bronx, New York" into a list; HA needs a string.
+        ha = dict(HA_DISCOVERY,
+                  device={'name': ['Bronx', 'New York'],
+                          'manufacturer': 'WeeWX',
+                          'model': ['Vantage', 'Pro2'],
+                          'identifiers': 'weewx'})
+        configs = dict(make_thread(ha=ha)._discovery_configs(US_RECORD))
+        dev = configs['homeassistant/sensor/weewx/outTemp/config']['device']
+        self.assertEqual(dev['name'], 'Bronx, New York')
+        self.assertEqual(dev['model'], 'Vantage, Pro2')
+        self.assertEqual(dev['identifiers'], ['weewx'])
+        for key in ('name', 'manufacturer', 'model'):
+            self.assertIsInstance(dev[key], str)
+
+
+class DeviceClassUnitValidationTest(unittest.TestCase):
+    """HA rejects an entity whose unit is invalid for its device_class. We keep
+    the (correct) unit and drop the device_class instead."""
+
+    def test_us_rainrate_keeps_device_class(self):
+        c = dict(make_thread()._discovery_configs(US_RECORD))
+        p = c['homeassistant/sensor/weewx/rainRate/config']
+        self.assertEqual(p['unit_of_measurement'], 'in/h')
+        self.assertEqual(p['device_class'], 'precipitation_intensity')
+
+    def test_metric_rainrate_drops_invalid_device_class(self):
+        # weewx METRIC reports rainRate in cm/h, which HA does NOT accept for
+        # precipitation_intensity.
+        rec = {'dateTime': 1781339400, 'usUnits': weewx.METRIC, 'interval': 5,
+               'rainRate': 0.5, 'rain': 0.1}
+        c = dict(make_thread()._discovery_configs(rec))
+        p = c['homeassistant/sensor/weewx/rainRate/config']
+        self.assertEqual(p['unit_of_measurement'], 'cm/h')   # unit kept (the truth)
+        self.assertNotIn('device_class', p)                  # invalid pairing dropped
+        self.assertEqual(p['state_class'], 'measurement')    # still a measurement
+        # rain (cm) is valid for the 'precipitation' device_class, so it stays.
+        self.assertEqual(c['homeassistant/sensor/weewx/rain/config']['device_class'],
+                         'precipitation')
+
+
+class NoUnitsLabelTest(unittest.TestCase):
+    """With append_units_label=False the topic/key carries no unit suffix, so
+    unit_of_measurement is the ONLY way HA learns the unit -- it must still be set,
+    and must match the published (suffix-less) field name."""
+
+    def test_uom_set_and_name_has_no_suffix_us(self):
+        configs = dict(make_thread(append_units_label=False)._discovery_configs(US_RECORD))
+        t = configs['homeassistant/sensor/weewx/outTemp/config']
+        self.assertEqual(t['unit_of_measurement'], '°F')   # unit still reported
+        self.assertEqual(t['value_template'], '{{ value_json.outTemp }}')  # no _F
+
+    def test_uom_follows_metric(self):
+        configs = dict(make_thread(append_units_label=False)._discovery_configs(METRICWX_RECORD))
+        t = configs['homeassistant/sensor/weewx/outTemp/config']
+        self.assertEqual(t['unit_of_measurement'], '°C')
+        self.assertEqual(t['value_template'], '{{ value_json.outTemp }}')
+
+    def test_per_input_unit_override(self):
+        # US station, but outTemp forced to degree_C via inputs, label off.
+        ha = dict(HA_DISCOVERY)
+        t = make_thread(ha=ha, append_units_label=False,
+                        inputs={'outTemp': {'unit': 'degree_C'}})
+        configs = dict(t._discovery_configs(US_RECORD))
+        c = configs['homeassistant/sensor/weewx/outTemp/config']
+        self.assertEqual(c['unit_of_measurement'], '°C')
+        self.assertEqual(c['value_template'], '{{ value_json.outTemp }}')
+
+    def test_each_observation_is_its_own_entity(self):
+        # outTemp and inTemp are distinct entities/topics -- no F/C collision even
+        # though neither name carries a unit suffix.
+        configs = dict(make_thread(append_units_label=False)._discovery_configs(US_RECORD))
+        out = configs['homeassistant/sensor/weewx/outTemp/config']
+        inn = configs['homeassistant/sensor/weewx/inTemp/config']
+        self.assertNotEqual(out['unique_id'], inn['unique_id'])
+        self.assertNotEqual(out['value_template'], inn['value_template'])
+
+
+class TimestampTest(unittest.TestCase):
+    """dateTime becomes a proper, descriptively-named HA timestamp entity."""
+
+    def test_timestamp_semantics_aggregate(self):
+        c = dict(make_thread()._discovery_configs(US_RECORD))
+        p = c['homeassistant/sensor/weewx/dateTime/config']
+        self.assertEqual(p['device_class'], 'timestamp')
+        self.assertEqual(p['name'], 'Observation Time')      # not a generic "Date Time"
+        self.assertEqual(p['unique_id'], 'weewx_observation_time')
+        self.assertEqual(p['object_id'], 'weewx_observation_time')
+        # HA forbids state_class / unit on a timestamp entity.
+        self.assertNotIn('state_class', p)
+        self.assertNotIn('unit_of_measurement', p)
+        # Epoch is converted to a datetime for HA.
+        self.assertEqual(p['value_template'], '{{ as_datetime(value_json.dateTime | float) }}')
+
+    def test_timestamp_individual_mode(self):
+        c = dict(make_thread(aggregation='individual')._discovery_configs(US_RECORD))
+        p = c['homeassistant/sensor/weewx/dateTime/config']
+        self.assertEqual(p['state_topic'], 'weather/dateTime')
+        self.assertEqual(p['value_template'], '{{ as_datetime(value | float) }}')
+
+
+class SkipFieldsTest(unittest.TestCase):
+
+    def test_mandatory_fields_always_skipped(self):
+        configs = dict(make_thread()._discovery_configs(US_RECORD))
+        for skip in ('interval', 'usUnits'):
+            self.assertNotIn('homeassistant/sensor/weewx/%s/config' % skip, configs)
+        # dateTime is NOT skipped: it is published as a timestamp entity.
+        self.assertIn('homeassistant/sensor/weewx/dateTime/config', configs)
+
+    def test_admin_skip_fields_excluded(self):
+        ha = dict(HA_DISCOVERY, skip_fields=['inTemp', 'inHumidity'])
+        configs = dict(make_thread(ha=ha)._discovery_configs(US_RECORD))
+        self.assertNotIn('homeassistant/sensor/weewx/inTemp/config', configs)
+        self.assertNotIn('homeassistant/sensor/weewx/inHumidity/config', configs)
+        # Other observations are still announced.
+        self.assertIn('homeassistant/sensor/weewx/outTemp/config', configs)
+
+    def test_skip_fields_union_with_mandatory(self):
+        # Even when the admin sets skip_fields, the mandatory ones stay excluded.
+        ha = dict(HA_DISCOVERY, skip_fields=['inTemp'])
+        t = make_thread(ha=ha)
+        self.assertTrue({'usUnits', 'interval', 'inTemp'} <= t.skip_fields)
+
+
+class UnitSystemConversionTest(unittest.TestCase):
+    """Setting unit_system converts the published data; discovery should follow."""
+
+    def _run(self, unit_system):
+        t = make_thread(unit_system=unit_system)
+        t.mc = FakeClient()
+        t.get_mqtt_client = lambda: None
+        t.process_record(dict(US_RECORD), None)
+        published = dict((tp[0], tp[1]) for tp in t.mc.published)
+        return t, published
+
+    def test_no_unit_system_keeps_us(self):
+        _t, pub = self._run(None)
+        self.assertIn('outTemp_F', pub['weather/loop'])
+        cfg = mqtt.json.loads(pub['homeassistant/sensor/weewx/outTemp/config'])
+        self.assertEqual(cfg['unit_of_measurement'], '°F')
+
+    def test_metricwx_converts(self):
+        _t, pub = self._run(weewx.METRICWX)
+        # filter_data renamed/relabeled the field to metric, and discovery agrees.
+        self.assertIn('outTemp_C', pub['weather/loop'])
+        cfg = mqtt.json.loads(pub['homeassistant/sensor/weewx/outTemp/config'])
+        self.assertEqual(cfg['unit_of_measurement'], '°C')
+        self.assertEqual(cfg['value_template'], '{{ value_json.outTemp_C }}')
+
+
+class MissingUsUnitsTest(unittest.TestCase):
+    """A record may or may not carry usUnits; without it we cannot describe the
+    data, and discovery must skip gracefully and retry later (never get stuck)."""
+
+    NO_UNITS = {'dateTime': 1781339400, 'interval': 30,
+                'outTemp': 61.0, 'barometer': 29.95}
+
+    def test_configs_empty_without_usunits(self):
+        # No crash, just nothing to announce.
+        self.assertEqual(make_thread()._discovery_configs(self.NO_UNITS), [])
+
+    def test_publish_skips_and_does_not_latch(self):
+        t = make_thread()
+        t.mc = FakeClient()
+        t.get_mqtt_client = lambda: None
+        t.publish_ha_discovery(self.NO_UNITS)
+        self.assertEqual(t.mc.published, [], "nothing should be published")
+        self.assertFalse(t._discovery_sent,
+                         "must not latch: a later record should still trigger it")
+
+    def test_retries_on_later_valid_record(self):
+        t = make_thread()
+        t.mc = FakeClient()
+        t.get_mqtt_client = lambda: None
+        # First attempt: no usUnits -> skipped, not latched.
+        t.publish_ha_discovery(self.NO_UNITS)
+        self.assertFalse(t._discovery_sent)
+        # Later record carries usUnits -> discovery is published and latched.
+        t.publish_ha_discovery(dict(US_RECORD))
+        disc = [tp for tp in t.mc.published if tp[0].startswith('homeassistant/')]
+        self.assertTrue(disc)
+        self.assertTrue(t._discovery_sent)
+
+    def test_process_record_skips_without_crashing(self):
+        # The whole data path (augment/convert/label) needs usUnits; a record
+        # without it must be skipped, not raise (which would kill the thread).
+        t = make_thread()
+        t.mc = FakeClient()
+        t.get_mqtt_client = lambda: None
+        t.process_record(dict(self.NO_UNITS), None)  # must not raise
+        self.assertEqual(t.mc.published, [])
+        self.assertFalse(t._discovery_sent)
+        # A subsequent valid record is still processed normally.
+        t.process_record(dict(US_RECORD), None)
+        self.assertTrue(any(tp[0].startswith('weather/') for tp in t.mc.published))
+        self.assertTrue(t._discovery_sent)
+
+
+class TriggerTest(unittest.TestCase):
+
+    def test_discovery_published_once_before_data(self):
+        t = make_thread()
+        t.mc = FakeClient()
+        t.get_mqtt_client = lambda: None  # don't touch the network
+        t.process_record(dict(US_RECORD), None)
+
+        disc = [tp for tp in t.mc.published if tp[0].startswith('homeassistant/')]
+        data = [tp for tp in t.mc.published if tp[0].startswith('weather/')]
+        self.assertTrue(disc, "expected discovery configs on the first record")
+        self.assertTrue(all(tp[2] for tp in disc), "discovery must be retained")
+        self.assertTrue(data, "expected data to be published too")
+        self.assertTrue(t._discovery_sent)
+
+        # Second record in the same run must NOT re-publish discovery.
+        t.mc.published = []
+        t.process_record(dict(US_RECORD), None)
+        disc2 = [tp for tp in t.mc.published if tp[0].startswith('homeassistant/')]
+        self.assertEqual(disc2, [], "discovery should only be sent once")
+
+    def test_disabled_discovery_publishes_no_configs(self):
+        t = make_thread(ha={'enable': False})
+        t.mc = FakeClient()
+        t.get_mqtt_client = lambda: None
+        t.process_record(dict(US_RECORD), None)
+        disc = [tp for tp in t.mc.published if tp[0].startswith('homeassistant/')]
+        self.assertEqual(disc, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bin/user/tests/test_mqtt_discovery.py
+++ b/bin/user/tests/test_mqtt_discovery.py
@@ -21,8 +21,10 @@ except ImportError:
     import Queue
 
 # Make 'import mqtt' work whether or not the extension is installed as user.mqtt.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import mqtt  # noqa: E402
+from fakes import FakeClient  # noqa: E402
 
 import weewx  # noqa: E402
 
@@ -62,16 +64,6 @@ def make_thread(ha=None, **kwargs):
                 ha_discovery=copy.deepcopy(HA_DISCOVERY if ha is None else ha))
     opts.update(kwargs)
     return mqtt.MQTTThread(Queue.Queue(), **opts)
-
-
-class FakeClient:
-    """Minimal stand-in for a paho client that records what was published."""
-    def __init__(self):
-        self.published = []
-
-    def publish(self, topic, payload=None, retain=False, qos=0):
-        self.published.append((topic, payload, retain))
-        return (mqtt.mqtt.MQTT_ERR_SUCCESS, 1)
 
 
 class DiscoveryUnitsTest(unittest.TestCase):
@@ -248,7 +240,6 @@ class UnitSystemConversionTest(unittest.TestCase):
     def _run(self, unit_system):
         t = make_thread(unit_system=unit_system)
         t.mc = FakeClient()
-        t.get_mqtt_client = lambda: None
         t.process_record(dict(US_RECORD), None)
         published = dict((tp[0], tp[1]) for tp in t.mc.published)
         return t, published
@@ -282,7 +273,6 @@ class MissingUsUnitsTest(unittest.TestCase):
     def test_publish_skips_and_does_not_latch(self):
         t = make_thread()
         t.mc = FakeClient()
-        t.get_mqtt_client = lambda: None
         t.publish_ha_discovery(self.NO_UNITS)
         self.assertEqual(t.mc.published, [], "nothing should be published")
         self.assertFalse(t._discovery_sent,
@@ -291,7 +281,6 @@ class MissingUsUnitsTest(unittest.TestCase):
     def test_retries_on_later_valid_record(self):
         t = make_thread()
         t.mc = FakeClient()
-        t.get_mqtt_client = lambda: None
         # First attempt: no usUnits -> skipped, not latched.
         t.publish_ha_discovery(self.NO_UNITS)
         self.assertFalse(t._discovery_sent)
@@ -306,7 +295,6 @@ class MissingUsUnitsTest(unittest.TestCase):
         # without it must be skipped, not raise (which would kill the thread).
         t = make_thread()
         t.mc = FakeClient()
-        t.get_mqtt_client = lambda: None
         t.process_record(dict(self.NO_UNITS), None)  # must not raise
         self.assertEqual(t.mc.published, [])
         self.assertFalse(t._discovery_sent)
@@ -321,7 +309,6 @@ class TriggerTest(unittest.TestCase):
     def test_discovery_published_once_before_data(self):
         t = make_thread()
         t.mc = FakeClient()
-        t.get_mqtt_client = lambda: None  # don't touch the network
         t.process_record(dict(US_RECORD), None)
 
         disc = [tp for tp in t.mc.published if tp[0].startswith('homeassistant/')]
@@ -340,7 +327,6 @@ class TriggerTest(unittest.TestCase):
     def test_disabled_discovery_publishes_no_configs(self):
         t = make_thread(ha={'enable': False})
         t.mc = FakeClient()
-        t.get_mqtt_client = lambda: None
         t.process_record(dict(US_RECORD), None)
         disc = [tp for tp in t.mc.published if tp[0].startswith('homeassistant/')]
         self.assertEqual(disc, [])

--- a/changelog
+++ b/changelog
@@ -1,3 +1,22 @@
+0.25 13jun2026
+* added Home Assistant MQTT discovery (new [[[ha_discovery]]] section).
+  Discovery is published once, retained, before the first data packet, and can
+  also be (re)published on demand with 'weectl rest run MQTT --discovery'.
+  Discovery describes the data as published: set 'unit_system = METRICWX' to
+  announce metric/SI units to HA, or leave it unset to announce native units.
+  Use 'skip_fields' to omit observations from discovery (they are still
+  published as MQTT data; only their discovery message is suppressed).
+  dateTime is announced as a HA 'timestamp' entity named "Observation Time"
+  (its Unix-epoch value is converted to a datetime in the value_template).
+  Device name/model/manufacturer are coerced to strings, so a comma-containing
+  station location (parsed by ConfigObj as a list) no longer makes HA reject
+  the discovery message.
+  A device_class is dropped when the published unit is not one HA accepts for
+  it (e.g. rainRate in cm/h under unit_system=METRIC), keeping the correct unit
+  instead of letting HA reject the entity.
+* fixed: a comma-separated 'aggregation' value (parsed as a list) crashed
+  process_record; it is now normalized to a string.
+
 0.24 16apr2022
 * renamed option 'units' to 'unit', although either will be accepted.
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,31 @@
+0.26 16aug2026
+* fixed: once the connection to the broker was lost, the client was never
+  checked or rebuilt, so every subsequent post failed with "The client is not
+  currently connected" until weewx was restarted. The connection is now
+  verified before each post and rebuilt when it has gone.
+* fixed: a failed publish was only logged, never reported, so weewx went on to
+  log a successful post for a record that was never delivered. A record that
+  cannot be delivered is now reported as a failure.
+* fixed: 'max_tries' and 'retry_wait' were accepted but ignored; a post is now
+  retried on a fresh connection, since weewx does not retry for this service.
+* fixed: individual observations were always published at qos 0, ignoring the
+  configured 'qos'.
+* the connection is now established properly: the client waits for the broker
+  to acknowledge it (CONNACK) instead of assuming an opened socket is usable,
+  so a refused connection is reported as itself (e.g. "not authorised")
+  instead of surfacing later as a publish failure.
+* connects and disconnects are logged, so an outage is visible when it happens
+  rather than at the next archive interval.
+* at qos 1 or 2, delivery is confirmed by the broker before a post is
+  considered successful.
+* the default 'qos' is now 1. At qos 0 anything published while the connection
+  is down is silently dropped, losing the record.
+* new options: 'keepalive', 'connect_timeout', 'publish_timeout',
+  'reconnect_min_delay', 'reconnect_max_delay'.
+* supports paho-mqtt 2.x as well as 1.x.
+* Home Assistant discovery is re-announced after a reconnect, in case the
+  broker came back without its retained messages.
+
 0.25 13jun2026
 * added Home Assistant MQTT discovery (new [[[ha_discovery]]] section).
   Discovery is published once, retained, before the first data packet, and can

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class MQTTInstaller(ExtensionInstaller):
     def __init__(self):
         super(MQTTInstaller, self).__init__(
-            version="0.24",
+            version="0.25",
             name='mqtt',
             description='Upload weather data to MQTT server.',
             author="Matthew Wall",
@@ -19,6 +19,22 @@ class MQTTInstaller(ExtensionInstaller):
             config={
                 'StdRESTful': {
                     'MQTT': {
-                        'server_url': 'INSERT_SERVER_URL_HERE'}}},
+                        'server_url': 'INSERT_SERVER_URL_HERE',
+                        # Home Assistant MQTT discovery. Set enable = true to have
+                        # weewx announce its sensors to Home Assistant. Discovery
+                        # reports whatever units are published; to send metric/SI
+                        # units to HA, set 'unit_system = METRICWX' above.
+                        # 'skip_fields' only suppresses the discovery message for
+                        # the listed fields -- those fields are STILL published as
+                        # normal MQTT data; it does not stop them being sent.
+                        'ha_discovery': {
+                            'enable': 'false',
+                            'discovery_prefix': 'homeassistant',
+                            'node_id': 'weewx',
+                            'unique_id_prefix': 'weewx',
+                            'skip_fields': '',
+                            'device': {
+                                'manufacturer': 'WeeWX',
+                            }}}}},
             files=[('bin/user', ['bin/user/mqtt.py'])]
             )

--- a/install.py
+++ b/install.py
@@ -10,7 +10,7 @@ def loader():
 class MQTTInstaller(ExtensionInstaller):
     def __init__(self):
         super(MQTTInstaller, self).__init__(
-            version="0.25",
+            version="0.26",
             name='mqtt',
             description='Upload weather data to MQTT server.',
             author="Matthew Wall",


### PR DESCRIPTION
- `README.md` has discovery information in it
- Can be configured to be on. Default: off